### PR TITLE
DNS delegation of hosted zone

### DIFF
--- a/config/templates/s3_access_policy.json.tpl
+++ b/config/templates/s3_access_policy.json.tpl
@@ -3,8 +3,18 @@
   "Statement": [
     {
       "Action": [
-        "s3:GetBucketAcl",
-        "s3:PutObject"
+        "s3:DeleteObject",
+        "s3:DeleteObjectTagging",
+        "s3:DeleteObjectVersion",
+        "s3:GetObjectAcl",
+        "s3:GetObject",
+        "s3:GetObjectTagging",
+        "s3:GetObjectVersion",
+        "s3:PutObject",
+        "s3:PutObjectAcl",
+        "s3:PutObjectVersionAcl",
+        "s3:PutObjectTagging",
+        "s3:PutObjectVersionTagging"
       ],
       "Effect": "Allow",
       "Resource": [

--- a/route53/main.tf
+++ b/route53/main.tf
@@ -8,7 +8,8 @@ resource "aws_route53_zone" "hosted_zone" {
     )
   )
 }
-
+# uncomment the block below if importing an existing hosted zone to the Terraform state file
+/*
 resource "aws_route53_record" "hosted_zone_ns" {
   zone_id = aws_route53_zone.hosted_zone.zone_id
   name    = var.environment_full_name == "production" ? "${var.project}.${var.domain}" : "${var.project}-${var.environment_full_name}.${var.domain}"
@@ -22,3 +23,4 @@ resource "aws_route53_record" "hosted_zone_ns" {
     "${aws_route53_zone.hosted_zone.name_servers.3}.",
   ]
 }
+*/

--- a/route53/main.tf
+++ b/route53/main.tf
@@ -10,7 +10,7 @@ resource "aws_route53_zone" "hosted_zone" {
 }
 # conditional includes the block below for environments with a manually created hosted zone imported to the Terraform state file
 resource "aws_route53_record" "hosted_zone_ns" {
-  count   = var.environment_full_name == "management" || var.environment_full_name == "staging" ? 1 : 0
+  count   = var.environment_full_name == "management" || var.environment_full_name == "integration" ? 1 : 0
   zone_id = aws_route53_zone.hosted_zone.zone_id
   name    = var.environment_full_name == "production" ? "${var.project}.${var.domain}" : "${var.project}-${var.environment_full_name}.${var.domain}"
   type    = "NS"

--- a/route53/main.tf
+++ b/route53/main.tf
@@ -8,9 +8,9 @@ resource "aws_route53_zone" "hosted_zone" {
     )
   )
 }
-# uncomment the block below if importing an existing hosted zone to the Terraform state file
-/*
+# conditional includes the block below for environments with a manually created hosted zone imported to the Terraform state file
 resource "aws_route53_record" "hosted_zone_ns" {
+  count   = var.environment_full_name == "management" || var.environment_full_name == "staging" ? 1 : 0
   zone_id = aws_route53_zone.hosted_zone.zone_id
   name    = var.environment_full_name == "production" ? "${var.project}.${var.domain}" : "${var.project}-${var.environment_full_name}.${var.domain}"
   type    = "NS"
@@ -23,4 +23,3 @@ resource "aws_route53_record" "hosted_zone_ns" {
     "${aws_route53_zone.hosted_zone.name_servers.3}.",
   ]
 }
-*/

--- a/ses/main.tf
+++ b/ses/main.tf
@@ -26,12 +26,12 @@ resource "aws_ses_domain_dkim" "email_dkim" {
 
 # include environment in conditional statement until DNS delegation is in place
 resource "aws_route53_record" "amazonses_dkim_record" {
-  count  = var.environment_full_name == "production" ? 0 : 3
+  count   = var.environment_full_name == "production" ? 0 : 3
   zone_id = var.hosted_zone_id
-  name    = "${element(aws_ses_domain_dkim.email_dkim.*.dkim_tokens[0],count.index)}._domainkey.${local.domain}"
+  name    = "${element(aws_ses_domain_dkim.email_dkim.*.dkim_tokens[0], count.index)}._domainkey.${local.domain}"
   type    = "CNAME"
   ttl     = "600"
-  records = ["${element(aws_ses_domain_dkim.email_dkim.*.dkim_tokens[0],count.index)}.dkim.amazonses.com"]
+  records = ["${element(aws_ses_domain_dkim.email_dkim.*.dkim_tokens[0], count.index)}.dkim.amazonses.com"]
 }
 
 resource "aws_ses_email_identity" "email_address" {

--- a/ses/main.tf
+++ b/ses/main.tf
@@ -10,23 +10,28 @@ resource "aws_route53_record" "amazonses_verification_record" {
   records = [aws_ses_domain_identity.email_domain.verification_token]
 }
 
+# include environment in conditional statement until DNS delegation is in place
 resource "aws_ses_domain_identity_verification" "email_verification" {
+  count  = var.environment_full_name == "production" ? 0 : 1
   domain = aws_ses_domain_identity.email_domain.id
 
   depends_on = [aws_route53_record.amazonses_verification_record]
 }
 
+# include environment in conditional statement until DNS delegation is in place
 resource "aws_ses_domain_dkim" "email_dkim" {
+  count  = var.environment_full_name == "production" ? 0 : 1
   domain = aws_ses_domain_identity.email_domain.domain
 }
 
+# include environment in conditional statement until DNS delegation is in place
 resource "aws_route53_record" "amazonses_dkim_record" {
-  count   = 3
+  count  = var.environment_full_name == "production" ? 0 : 3
   zone_id = var.hosted_zone_id
-  name    = "${element(aws_ses_domain_dkim.email_dkim.dkim_tokens, count.index)}._domainkey.${local.domain}"
+  name    = "${element(aws_ses_domain_dkim.email_dkim.*.dkim_tokens[0],count.index)}._domainkey.${local.domain}"
   type    = "CNAME"
   ttl     = "600"
-  records = ["${element(aws_ses_domain_dkim.email_dkim.dkim_tokens, count.index)}.dkim.amazonses.com"]
+  records = ["${element(aws_ses_domain_dkim.email_dkim.*.dkim_tokens[0],count.index)}.dkim.amazonses.com"]
 }
 
 resource "aws_ses_email_identity" "email_address" {


### PR DESCRIPTION
Allows Jenkins pipeline to run without errors before, and after, DNS delegation of a newly created hosted zone is in place