### PR TITLE
Add optional cors config to the bucket.

### DIFF
--- a/s3/main.tf
+++ b/s3/main.tf
@@ -70,6 +70,16 @@ resource "aws_s3_bucket" "bucket" {
     }
   }
 
+  dynamic "cors_rule" {
+    for_each = var.cors == true ? ["include-cors"] : []
+    content {
+      allowed_headers = ["*"]
+      allowed_methods = ["PUT", "POST", "GET"]
+      allowed_origins = [var.frontend_url]
+      expose_headers  = ["ETag"]
+    }
+  }
+
   tags = merge(
     var.common_tags,
     map(

--- a/s3/variables.tf
+++ b/s3/variables.tf
@@ -51,5 +51,14 @@ variable "bucket_policy" {
 
 variable "kms_key_id" {
   description = "KMS Key ID to encrypt S3 bucket"
+}
+
+variable "cors" {
+  description = "adds allowed origins for the stage front end to the bucket to allow uploads from the browser"
+  default     = false
+}
+
+variable "frontend_url" {
+  description = "the url of the frontend. This is only needed if adding cors support so it defaults to empty string"
   default     = ""
 }


### PR DESCRIPTION
Buckets that are accessed from the browser need cors configuration. For
now, I've set the allowed hosts to be the frontend only which will
probably be all we need but we can change it later if needs be.