### PR TITLE
Make the ALB health check unhealthy threshold configurable

### DIFF
--- a/alb/main.tf
+++ b/alb/main.tf
@@ -43,7 +43,7 @@ resource "aws_alb_target_group" "alb_module" {
     matcher             = var.health_check_matcher
     timeout             = "3"
     path                = "/${var.health_check_path}"
-    unhealthy_threshold = "2"
+    unhealthy_threshold = var.health_check_unhealthy_threshold
   }
   tags = merge(
     var.common_tags,

--- a/alb/variables.tf
+++ b/alb/variables.tf
@@ -46,6 +46,12 @@ variable "health_check_matcher" {
   default     = "200"
 }
 
+variable "health_check_unhealthy_threshold" {
+  description = "The number of consecutive failed health checks required to mark the target as unhealthy"
+  type        = number
+  default     = 2
+}
+
 variable "http_listener" {
   description = "HTTP listener on port 80 for HTTP to HTTPS redirect"
   default     = true


### PR DESCRIPTION
Allow clients to set the number of health checks which need to fail before an application is considered unhealthy.

This will let us raise the threshold for Jenkins, which is sometimes down for a few minutes while restarting. In that case, it's better to wait to see whether it starts up again before deploying a new ECS container.