### PR TITLE
Add polices for SQS queues

### DIFF
--- a/sqs/data.tf
+++ b/sqs/data.tf
@@ -1,0 +1,1 @@
+data "aws_caller_identity" "current" {}

--- a/sqs/main.tf
+++ b/sqs/main.tf
@@ -1,6 +1,7 @@
 resource "aws_sqs_queue" "sqs_queue" {
-  count = var.apply_resource == true ? 1 : 0
-  name  = local.sqs_name
+  count  = var.apply_resource == true ? 1 : 0
+  name   = local.sqs_name
+  policy = templatefile("./tdr-terraform-modules/sqs/templates/${var.sqs_policy}_policy.json.tpl", { region = var.region, account_id = data.aws_caller_identity.current.account_id, sqs_name = local.sqs_name })
 
   tags = merge(
     var.common_tags,

--- a/sqs/templates/default_policy.json.tpl
+++ b/sqs/templates/default_policy.json.tpl
@@ -1,0 +1,21 @@
+{
+  "Version": "2012-10-17",
+  "Id": "default_policy",
+  "Statement": [
+    {
+      "Sid": "default_statement",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": [
+        "SQS:GetQueueAttributes",
+        "SQS:GetQueueUrl",
+        "SQS:ListDeadLetterSourceQueues",
+        "SQS:ReceiveMessage",
+        "SQS:SendMessage"
+      ],
+      "Resource": "arn:aws:sqs:${region}:${account_id}:${sqs_name}"
+    }
+  ]
+}

--- a/sqs/templates/sns_topic_policy.json.tpl
+++ b/sqs/templates/sns_topic_policy.json.tpl
@@ -1,0 +1,18 @@
+{
+  "Version": "2012-10-17",
+  "Id": "sns_topic_policy",
+  "Statement": [
+    {
+      "Sid": "sns_topic_statement",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "SQS:SendMessage",
+      "Resource": "arn:aws:sqs:${region}:${account_id}:${sqs_name}",
+      "Condition": {
+        "ArnEquals": {
+          "aws:SourceArn": "arn:aws:sns:${region}:${account_id}:*"
+        }
+      }
+    }
+  ]
+}

--- a/sqs/variables.tf
+++ b/sqs/variables.tf
@@ -25,3 +25,8 @@ variable "apply_resource" {
   description = "use to conditionally apply resource from the calling module"
   default     = true
 }
+
+variable "sqs_policy" {
+  description = "allows a custom SQS policy to be set"
+  default     = "default"
+}


### PR DESCRIPTION
SQS queues require policy to provide permissions to perform actions on the SQS queue

Default policy provides general permissions

SNS Topics policy provides specific permissions for SNS topics