### PR TITLE
Allow multiple CORS origins to upload to an S3 bucket

### DIFF
--- a/lambda/log_data.tf
+++ b/lambda/log_data.tf
@@ -60,7 +60,7 @@ resource "aws_lambda_function" "log_data_lambda" {
   }
 
   lifecycle {
-    ignore_changes = ["last_modified"]
+    ignore_changes = [last_modified]
   }
 }
 

--- a/s3/main.tf
+++ b/s3/main.tf
@@ -87,11 +87,11 @@ resource "aws_s3_bucket" "bucket" {
   }
 
   dynamic "cors_rule" {
-    for_each = var.cors == true ? ["include-cors"] : []
+    for_each = length(var.cors_urls) > 0 ? ["include-cors"] : []
     content {
       allowed_headers = ["*"]
       allowed_methods = ["PUT", "POST", "GET"]
-      allowed_origins = [var.frontend_url]
+      allowed_origins = var.cors_urls
       expose_headers  = ["ETag"]
     }
   }

--- a/s3/variables.tf
+++ b/s3/variables.tf
@@ -63,14 +63,10 @@ variable "kms_key_id" {
   default     = ""
 }
 
-variable "cors" {
-  description = "adds allowed origins for the stage front end to the bucket to allow uploads from the browser"
-  default     = false
-}
-
-variable "frontend_url" {
-  description = "the url of the frontend. This is only needed if adding cors support so it defaults to empty string"
-  default     = ""
+variable "cors_urls" {
+  description = "frontend URLs that are allowed to make cross-origin request to the bucket"
+  type        = list(string)
+  default     = []
 }
 
 variable "force_destroy" {


### PR DESCRIPTION
Update the parameters for the S3 module so that multiple frontend origins can be passed in a parameter.

This will allow us to configure integration so that files can be uploaded from the local dev environment as well as from the integration frontend, which makes it possible to do local dev against a real integration S3 bucket.

If no origins are passed, do not enable CORS at all.

Also fix a Terraform syntax warning.