### PR TITLE
Fix SSM parameter issue in mgmt

### DIFF
--- a/lambda/api_update_av.tf
+++ b/lambda/api_update_av.tf
@@ -14,7 +14,7 @@ resource "aws_lambda_function" "lambda_api_update_function" {
       API_URL       = "${var.api_url}/graphql"
       AUTH_URL      = var.auth_url
       CLIENT_ID     = "tdr-backend-checks"
-      CLIENT_SECRET = data.aws_ssm_parameter.keycloak_backend_checks_client_secret.value
+      CLIENT_SECRET = var.keycloak_backend_checks_client_secret
     }
   }
 }

--- a/lambda/variables.tf
+++ b/lambda/variables.tf
@@ -45,3 +45,8 @@ variable "api_url" {
   description = "The url of the graphql api"
   default     = ""
 }
+
+variable "keycloak_backend_checks_client_secret" {
+  description = "Keycloak backend checks client secret"
+  default = ""
+}


### PR DESCRIPTION
Allows terraform to run without errors in environments like mgmt where this SSM parameter doesn't exist