### PR TITLE
Permissions for copying S3 objects across accounts

### DIFF
--- a/lambda/api_update_av.tf
+++ b/lambda/api_update_av.tf
@@ -19,10 +19,6 @@ resource "aws_lambda_function" "lambda_api_update_function" {
   }
 }
 
-data "aws_ssm_parameter" "keycloak_backend_checks_client_secret" {
-  name = "/${local.environment}/keycloak/backend_checks_client/secret"
-}
-
 resource "aws_lambda_function_event_invoke_config" "lambda_api_update_async_config" {
   count         = local.count_api_update_av
   function_name = aws_lambda_function.lambda_api_update_function.*.function_name[0]

--- a/lambda/functions/log-data/lambda_function.py
+++ b/lambda/functions/log-data/lambda_function.py
@@ -13,4 +13,4 @@ def lambda_handler(event, context):
     copy_source = {'Bucket':source_bucket, 'Key':key}
 
     print('Copying %s from bucket %s to bucket %s ...' % (key, source_bucket, target_bucket))
-    s3.copy_object(Bucket=target_bucket, Key=key, CopySource=copy_source)
+    s3.copy_object(Bucket=target_bucket, Key=key, CopySource=copy_source, ACL='bucket-owner-full-control')

--- a/lambda/templates/log_data.json.tpl
+++ b/lambda/templates/log_data.json.tpl
@@ -15,7 +15,8 @@
       "Sid": "PutLogs",
       "Effect": "Allow",
       "Action": [
-        "s3:PutObject"
+        "s3:PutObject",
+        "s3:PutObjectAcl"
       ],
       "Resource": "arn:aws:s3:::tdr-log-data-mgmt/*"
     }


### PR DESCRIPTION
Ensures the ACL of an object copied from one AWS account to another is transferred to the AWS account of the target bucket.

Removes a data lookup for an SSM parameter which is no longer required and causes an error in mgmt