### PR TITLE
Increased the timeouts for the lambdas.

### DIFF
--- a/lambda/checksum.tf
+++ b/lambda/checksum.tf
@@ -5,7 +5,7 @@ resource "aws_lambda_function" "checksum_lambda_function" {
   role          = aws_iam_role.checksum_lambda_iam_role.*.arn[0]
   runtime       = "java8"
   filename      = "${path.module}/functions/checksum.jar"
-  timeout       = 20
+  timeout       = 180
   memory_size   = 1024
   tags          = var.common_tags
   environment {

--- a/lambda/yara_av.tf
+++ b/lambda/yara_av.tf
@@ -7,7 +7,7 @@ resource "aws_lambda_function" "lambda_function" {
   s3_bucket     = "tdr-backend-checks-${local.environment}"
   s3_key        = "yara-av.zip"
   timeout       = 180
-  memory_size   = 1024
+  memory_size   = 3008
   tags          = var.common_tags
   environment {
     variables = {

--- a/lambda/yara_av.tf
+++ b/lambda/yara_av.tf
@@ -6,7 +6,7 @@ resource "aws_lambda_function" "lambda_function" {
   runtime       = "python3.7"
   s3_bucket     = "tdr-backend-checks-${local.environment}"
   s3_key        = "yara-av.zip"
-  timeout       = 20
+  timeout       = 180
   memory_size   = 1024
   tags          = var.common_tags
   environment {


### PR DESCRIPTION
The checksum lambda processed a 3Gb file in just over two minutes so 3
seems like a reasonable compromise at this point.

I've increased the lambda to the same although it doesn't usually
appear to take this long. It keeps things consistent anyway and most
errors we get are memory or the code throwing exceptions so the number
of hanging lambdas should be negligable.