### PR TITLE
Rename efs file system for backend checks

### DIFF
--- a/efs/locals.tf
+++ b/efs/locals.tf
@@ -1,5 +1,6 @@
 locals {
-  workspace       = lower(terraform.workspace)
-  environment     = local.workspace == "default" ? "mgmt" : local.workspace
-  efs_volume_name = "${var.project}-${var.function}-${local.environment}"
+  workspace           = lower(terraform.workspace)
+  environment         = local.workspace == "default" ? "mgmt" : local.workspace
+  efs_volume_name     = "${var.project}-${var.function}-${local.environment}"
+  root_directory_path = "/mnt${var.access_point_path}"
 }

--- a/efs/outputs.tf
+++ b/efs/outputs.tf
@@ -5,3 +5,7 @@ output "access_point" {
 output "file_system_id" {
   value = aws_efs_file_system.file_system.id
 }
+
+output "root_directory_path" {
+  value = local.root_directory_path
+}

--- a/efs/templates/backend_checks_access_policy.json.tpl
+++ b/efs/templates/backend_checks_access_policy.json.tpl
@@ -1,9 +1,9 @@
 {
   "Version": "2012-10-17",
-  "Id": "efs-policy-file-format",
+  "Id": "efs-policy-backend-checks",
   "Statement": [
     {
-      "Sid": "efs-statement-file-format",
+      "Sid": "efs-statement-backend-checks",
       "Effect": "Allow",
       "Principal": {
         "AWS": "*"

--- a/lambda/download_files.tf
+++ b/lambda/download_files.tf
@@ -21,8 +21,8 @@ resource "aws_lambda_function" "download_files_lambda_function" {
   }
   file_system_config {
     # EFS file system access point ARN
-    arn              = var.file_format_efs_access_point.arn
-    local_mount_path = "/mnt/fileformat"
+    arn              = var.backend_checks_efs_access_point.arn
+    local_mount_path = var.backend_checks_efs_root_directory_path
   }
 
   vpc_config {

--- a/lambda/file_format.tf
+++ b/lambda/file_format.tf
@@ -10,15 +10,16 @@ resource "aws_lambda_function" "file_format_lambda_function" {
   tags          = var.common_tags
   environment {
     variables = {
-      ENVIRONMENT  = local.environment
-      INPUT_QUEUE  = local.file_format_queue_url
-      OUTPUT_QUEUE = local.api_update_queue_url
+      ENVIRONMENT    = local.environment
+      INPUT_QUEUE    = local.file_format_queue_url
+      OUTPUT_QUEUE   = local.api_update_queue_url
+      ROOT_DIRECTORY = var.backend_checks_efs_root_directory_path
     }
   }
   file_system_config {
     # EFS file system access point ARN
-    arn              = var.file_format_efs_access_point.arn
-    local_mount_path = "/mnt/fileformat"
+    arn              = var.backend_checks_efs_access_point.arn
+    local_mount_path = var.backend_checks_efs_root_directory_path
   }
 
   vpc_config {

--- a/lambda/variables.tf
+++ b/lambda/variables.tf
@@ -73,7 +73,7 @@ variable "backend_checks_efs_access_point" {
 
 variable "backend_checks_efs_root_directory_path" {
   description = "The root directory of the efs volume used by the backend checks"
-  default     = "/mnt"
+  default     = ""
 }
 
 variable "vpc_id" {

--- a/lambda/variables.tf
+++ b/lambda/variables.tf
@@ -66,9 +66,14 @@ variable "keycloak_backend_checks_client_secret" {
   default     = ""
 }
 
-variable "file_format_efs_access_point" {
-  description = "The access point for the efs volume used by the file format checks"
+variable "backend_checks_efs_access_point" {
+  description = "The access point for the efs volume used by the backend checks"
   default     = ""
+}
+
+variable "backend_checks_efs_root_directory_path" {
+  description = "The root directory of the efs volume used by the backend checks"
+  default     = "/mnt"
 }
 
 variable "vpc_id" {


### PR DESCRIPTION
EFS file system to be used by all backend checks initially named for file format check only

Rename resources to reflect use by all backend checks