### PR TITLE
Add tdr management email

### DIFF
--- a/ses/main.tf
+++ b/ses/main.tf
@@ -38,6 +38,6 @@ resource "aws_ses_email_identity" "email_address" {
   email = "${var.email_address}@${var.domain}"
 }
 
-resource "aws_ses_email_identity" "email_address" {
+resource "aws_ses_email_identity" "tdr_email_address" {
   email = "aws_tdr_management@${var.domain}"
 }

--- a/ses/main.tf
+++ b/ses/main.tf
@@ -37,3 +37,7 @@ resource "aws_route53_record" "amazonses_dkim_record" {
 resource "aws_ses_email_identity" "email_address" {
   email = "${var.email_address}@${var.domain}"
 }
+
+resource "aws_ses_email_identity" "email_address" {
+  email = "aws_tdr_management@${var.domain}"
+}


### PR DESCRIPTION
SES has been set up so that we need to add any addresses we want to send emails to. I imagine this can be configured somewhere but for now this is fine so I've added in the tdr_management address so we can send ECR scan notifications to that address.