### PR TITLE
Add a lifecycle policy to remove untagged images.

### DIFF
--- a/ecr/main.tf
+++ b/ecr/main.tf
@@ -13,3 +13,8 @@ resource "aws_ecr_repository_policy" "ecr_repository_policy" {
   policy     = templatefile("./tdr-terraform-modules/ecr/templates/${var.policy_name}.json.tpl", var.policy_variables)
   repository = aws_ecr_repository.ecr_repository.name
 }
+
+resource "aws_ecr_lifecycle_policy" "remove_untagged_images" {
+  policy = templatefile("${path.module}/templates/expire_untagged_images.json.tpl", {})
+  repository = aws_ecr_repository.ecr_repository.name
+}

--- a/ecr/main.tf
+++ b/ecr/main.tf
@@ -15,6 +15,6 @@ resource "aws_ecr_repository_policy" "ecr_repository_policy" {
 }
 
 resource "aws_ecr_lifecycle_policy" "remove_untagged_images" {
-  policy = templatefile("${path.module}/templates/expire_untagged_images.json.tpl", {})
+  policy     = templatefile("${path.module}/templates/expire_untagged_images.json.tpl", {})
   repository = aws_ecr_repository.ecr_repository.name
 }

--- a/ecr/templates/expire_untagged_images.json.tpl
+++ b/ecr/templates/expire_untagged_images.json.tpl
@@ -7,7 +7,7 @@
         "tagStatus": "untagged",
         "countType": "sinceImagePushed",
         "countUnit": "days",
-        "countNumber": 1
+        "countNumber": 7
       },
       "action": {
         "type": "expire"

--- a/ecr/templates/expire_untagged_images.json.tpl
+++ b/ecr/templates/expire_untagged_images.json.tpl
@@ -1,0 +1,17 @@
+{
+  "rules": [
+    {
+      "rulePriority": 1,
+      "description": "Remove untagged images",
+      "selection": {
+        "tagStatus": "untagged",
+        "countType": "sinceImagePushed",
+        "countUnit": "days",
+        "countNumber": 1
+      },
+      "action": {
+        "type": "expire"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
When we push an image to ecr with a tag which is already assigned to an
image, intg or latest or whichever, the original image is kept in an
untagged state.
There's no reason for us to keep these. They don't affect our rollback
process at all so they're just taking up space.
This rule will delete them once the image is over a day old.