### PR TITLE
Pass EC2 instance ID instead of name to maintenance window module

### DIFF
--- a/ssm_maintenance_window/data.tf
+++ b/ssm_maintenance_window/data.tf
@@ -1,7 +1,0 @@
-data aws_instance "target_instance" {
-  filter {
-    name   = "tag:Name"
-    values = [var.instance_name]
-  }
-}
-

--- a/ssm_maintenance_window/main.tf
+++ b/ssm_maintenance_window/main.tf
@@ -13,7 +13,7 @@ resource "aws_ssm_maintenance_window_target" "maintenance_window_target" {
   window_id     = aws_ssm_maintenance_window.maintenance_window.id
   targets {
     key    = "InstanceIds"
-    values = [data.aws_instance.target_instance.id]
+    values = [var.ec2_instance_id]
   }
 }
 
@@ -28,7 +28,7 @@ resource "aws_ssm_maintenance_window_task" "maintenance_window_task" {
 
   targets {
     key    = "InstanceIds"
-    values = [data.aws_instance.target_instance.id]
+    values = [var.ec2_instance_id]
   }
 
   task_invocation_parameters {

--- a/ssm_maintenance_window/variables.tf
+++ b/ssm_maintenance_window/variables.tf
@@ -6,8 +6,8 @@ variable "duration" {
 variable "cutoff" {
   default = 0
 }
-variable "instance_name" {
-  description = "The name of the target instance to run the command against"
+variable "ec2_instance_id" {
+  description = "The ID of the EC2 target instance to run the command against"
 }
 variable "command" {
   description = "The command to execute in the task executed by the maintenance window"


### PR DESCRIPTION
This forces the module to wait for the EC2 instance to be created, which means the maintenance task is run on the latest version of the instance.

This fixes a bug where the EC2 instance was updated, but Terraform couldn't tell that the instance ID needed to be updated to match.