### PR TITLE
Add image_source_url variable to ECR module

### DIFF
--- a/ecr/main.tf
+++ b/ecr/main.tf
@@ -5,7 +5,10 @@ resource "aws_ecr_repository" "ecr_repository" {
   image_scanning_configuration {
     scan_on_push = true
   }
-  tags = var.common_tags
+  tags = merge(
+    var.common_tags,
+    map("ImageSource", var.image_source_url)
+  )
 }
 
 resource "aws_ecr_repository_policy" "ecr_repository_policy" {

--- a/ecr/variables.tf
+++ b/ecr/variables.tf
@@ -5,6 +5,12 @@ variable "tag_mutability" {
 }
 variable "name" {}
 
+variable "image_source_url" {
+  type        = string
+  default     = "unknown"
+  description = "The URL of the Dockerfile or other source used to build the images in this repository"
+}
+
 variable "policy_name" {
   default = ""
 }


### PR DESCRIPTION
This parameter should be the URL of a Dockerfile or some other source of the Docker images stored in the ECR repository.

This parameter would be helpful when someone needs to fix the Docker image, e.g to fix a vulnerability found by an ECR image scan, but is unfamiliar with the ECR repo. The URL will help them find the right Dockerfile to build.

The default value of "unknown" will be removed once all the usages of this module pass the parameter.