### PR TITLE
Remove default ECR image source parameter

### DIFF
--- a/ecr/variables.tf
+++ b/ecr/variables.tf
@@ -7,7 +7,6 @@ variable "name" {}
 
 variable "image_source_url" {
   type        = string
-  default     = "unknown"
   description = "The URL of the Dockerfile or other source used to build the images in this repository"
 }
 


### PR DESCRIPTION
All of the existing ECR repos pass this parameter, so the default is no longer needed. Removing the default means that we won't forget to add the tag when we create new ECR repos.