### PR TITLE
Add lifecycle rule to delete aborted uploads

### DIFF
--- a/s3/main.tf
+++ b/s3/main.tf
@@ -79,6 +79,15 @@ resource "aws_s3_bucket" "bucket" {
     }
   }
 
+  dynamic "lifecycle_rule" {
+    for_each = var.abort_incomplete_uploads == true ? ["include_block"] : []
+    content {
+      id                                     = "abort-incomplete-uploads"
+      enabled                                = true
+      abort_incomplete_multipart_upload_days = 7
+    }
+  }
+
   dynamic "logging" {
     for_each = var.access_logs == true ? ["include_block"] : []
     content {

--- a/s3/variables.tf
+++ b/s3/variables.tf
@@ -32,6 +32,10 @@ variable "version_lifecycle" {
   default = false
 }
 
+variable "abort_incomplete_uploads" {
+  default = false
+}
+
 variable "block_public_acls" {
   default = true
 }


### PR DESCRIPTION
It's possible that we have multipart uploads which are partially completed, either because it's timed out, or the connection died or they closed the browser. This rule will delete anything that's older than 7 days. Documentation is here.
https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html#mpu-stop-incomplete-mpu-lifecycle-config
