### PR TITLE
Changes to allow notifications from other accounts

### DIFF
--- a/lambda/variables.tf
+++ b/lambda/variables.tf
@@ -118,6 +118,11 @@ variable "event_rule_arns" {
   default = []
 }
 
+variable "sns_topic_arns" {
+  type    = set(string)
+  default = []
+}
+
 variable "periodic_ecr_image_scan_event_arn" {
   default = ""
 }

--- a/sns/data.tf
+++ b/sns/data.tf
@@ -1,1 +1,5 @@
 data "aws_caller_identity" "current" {}
+
+data "aws_ssm_parameter" "mgmt_account_number" {
+  name = "/mgmt/management_account"
+}

--- a/sns/main.tf
+++ b/sns/main.tf
@@ -1,7 +1,7 @@
 resource "aws_sns_topic" "sns_topic" {
   count  = var.apply_resource == true ? 1 : 0
   name   = local.sns_topic_name
-  policy = templatefile("./tdr-terraform-modules/sns/templates/${var.sns_policy}.json.tpl", { region = var.region, account_id = data.aws_caller_identity.current.account_id, sns_topic_name = local.sns_topic_name })
+  policy = templatefile("./tdr-terraform-modules/sns/templates/${var.sns_policy}.json.tpl", { region = var.region, account_id = data.aws_caller_identity.current.account_id, sns_topic_name = local.sns_topic_name, management_account = data.aws_ssm_parameter.mgmt_account_number.value })
 
   tags = merge(
     var.common_tags,

--- a/sns/templates/notifications.json.tpl
+++ b/sns/templates/notifications.json.tpl
@@ -1,0 +1,42 @@
+{
+  "Version": "2012-10-17",
+  "Id": "default_policy",
+  "Statement": [
+    {
+      "Sid": "default_statement",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": [
+        "sns:GetTopicAttributes",
+        "sns:SetTopicAttributes",
+        "sns:AddPermission",
+        "sns:RemovePermission",
+        "sns:DeleteTopic",
+        "sns:Subscribe",
+        "sns:ListSubscriptionsByTopic",
+        "sns:Publish",
+        "sns:Receive"
+      ],
+      "Resource": "arn:aws:sns:${region}:${account_id}:${sns_topic_name}",
+      "Condition": {
+        "StringEquals": {
+          "AWS:SourceOwner": "${account_id}"
+        }
+      }
+    },
+    {
+      "Sid": "lambda-access",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${management_account}:root"
+      },
+      "Action": [
+        "SNS:Subscribe",
+        "SNS:ListSubscriptionsByTopic"
+      ],
+      "Resource": "arn:aws:sns:${region}:${account_id}:${sns_topic_name}"
+    }
+  ]
+}

--- a/sns/templates/notifications.json.tpl
+++ b/sns/templates/notifications.json.tpl
@@ -1,9 +1,9 @@
 {
   "Version": "2012-10-17",
-  "Id": "default_policy",
+  "Id": "allow_account_access_to_topic_policy",
   "Statement": [
     {
-      "Sid": "default_statement",
+      "Sid": "allow_account_access_to_topic",
       "Effect": "Allow",
       "Principal": {
         "AWS": "*"

--- a/stepfunctions/main.tf
+++ b/stepfunctions/main.tf
@@ -12,7 +12,7 @@ resource "aws_iam_role" "state_machine_role" {
 
 resource "aws_iam_policy" "state_machine_policy" {
   name   = "TDR${var.step_function_name}Policy${title(var.environment)}"
-  policy = templatefile("${path.module}/templates/${var.policy}_policy.json.tpl", merge(var.policy_variables, { account_id = data.aws_caller_identity.current.account_id }))
+  policy = templatefile("${path.module}/templates/${var.policy}_policy.json.tpl", merge(var.policy_variables, { account_id = data.aws_caller_identity.current.account_id, sns_topic = var.notification_sns_topic }))
 }
 
 resource "aws_iam_role_policy_attachment" "state_machine_attachment" {

--- a/stepfunctions/templates/consignment_export_policy.json.tpl
+++ b/stepfunctions/templates/consignment_export_policy.json.tpl
@@ -52,6 +52,13 @@
         "logs:UpdateLogDelivery"
       ],
       "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "sns:Publish"
+      ],
+      "Resource": "${sns_topic}"
     }
   ]
 }

--- a/stepfunctions/variables.tf
+++ b/stepfunctions/variables.tf
@@ -12,3 +12,6 @@ variable "policy_variables" {
   default = {}
   type    = map(string)
 }
+variable "notification_sns_topic" {
+  default = ""
+}


### PR DESCRIPTION
This has been set up so the step functions for the export can send notifications using the lambda in the management account but it can be used for anything that needs to send notifications from intg, staging or prod. If a message is sent to the sns topic tdr-notifications-$stage, it will trigger a notification.

There are notification lambda changes to add permissions for the sns queues to invoke the notification lambda.

There are changes to the sns topics to add a permission which allows the management account to subscribe to them.

Lastly, there are changes to the export step function to send a message to the sns topic on failure or success and a permission change to allow it to send those messages.
