### PR TITLE
Remove version expiration

### DIFF
--- a/s3/main.tf
+++ b/s3/main.tf
@@ -69,17 +69,6 @@ resource "aws_s3_bucket" "bucket" {
   versioning {
     enabled = var.versioning
   }
-  dynamic "lifecycle_rule" {
-    for_each = var.version_lifecycle == true ? ["include_block"] : []
-    content {
-      id      = "delete-old-versions"
-      enabled = true
-
-      noncurrent_version_expiration {
-        days = 30
-      }
-    }
-  }
 
   dynamic "lifecycle_rule" {
     for_each = var.abort_incomplete_uploads == true ? ["include_block"] : []

--- a/s3/variables.tf
+++ b/s3/variables.tf
@@ -28,10 +28,6 @@ variable "versioning" {
   default = true
 }
 
-variable "version_lifecycle" {
-  default = false
-}
-
 variable "abort_incomplete_uploads" {
   default = false
 }


### PR DESCRIPTION
Every S3 bucket is created using this module so removing it from here
will remove it from all buckets which had the version_lifecycle variable
set to true.
