### PR TITLE
Remove prod policies

### DIFF
--- a/ecr/templates/auth_server_policy.json.tpl
+++ b/ecr/templates/auth_server_policy.json.tpl
@@ -7,8 +7,7 @@
       "Principal": {
         "AWS": [
           "arn:aws:iam::${intg_account}:role/keycloak_ecs_execution_role_intg",
-          "arn:aws:iam::${staging_account}:role/keycloak_ecs_execution_role_staging",
-          "arn:aws:iam::${prod_account}:role/keycloak_ecs_execution_role_prod"
+          "arn:aws:iam::${staging_account}:role/keycloak_ecs_execution_role_staging"
         ]
       },
       "Action": [

--- a/ecr/templates/consignment_api_policy.json.tpl
+++ b/ecr/templates/consignment_api_policy.json.tpl
@@ -7,8 +7,7 @@
       "Principal": {
         "AWS": [
           "arn:aws:iam::${intg_account}:role/consignmentapi_ecs_execution_role_intg",
-          "arn:aws:iam::${staging_account}:role/consignmentapi_ecs_execution_role_staging",
-          "arn:aws:iam::${prod_account}:role/consignmentapi_ecs_execution_role_prod"
+          "arn:aws:iam::${staging_account}:role/consignmentapi_ecs_execution_role_staging"
         ]
       },
       "Action": [

--- a/ecr/templates/consignment_export_policy.json.tpl
+++ b/ecr/templates/consignment_export_policy.json.tpl
@@ -7,8 +7,7 @@
       "Principal": {
         "AWS": [
           "arn:aws:iam::${intg_account}:role/TDRConsignmentExportECSExecutionRoleIntg",
-          "arn:aws:iam::${staging_account}:role/TDRConsignmentExportECSExecutionRoleStaging",
-          "arn:aws:iam::${prod_account}:role/TDRConsignmentExportECSExecutionRoleProd"
+          "arn:aws:iam::${staging_account}:role/TDRConsignmentExportECSExecutionRoleStaging"
         ]
       },
       "Action": [

--- a/ecr/templates/file_format_policy.json.tpl
+++ b/ecr/templates/file_format_policy.json.tpl
@@ -7,8 +7,7 @@
       "Principal": {
         "AWS": [
           "arn:aws:iam::${intg_account}:role/TDRFileFormatECSExecutionRoleIntg",
-          "arn:aws:iam::${staging_account}:role/TDRFileFormatECSExecutionRoleStaging",
-          "arn:aws:iam::${prod_account}:role/TDRFileFormatECSExecutionRoleProd"
+          "arn:aws:iam::${staging_account}:role/TDRFileFormatECSExecutionRoleStaging"
         ]
       },
       "Action": [

--- a/ecr/templates/transfer_frontend_policy.json.tpl
+++ b/ecr/templates/transfer_frontend_policy.json.tpl
@@ -7,8 +7,7 @@
       "Principal": {
         "AWS": [
           "arn:aws:iam::${intg_account}:role/frontend_ecs_execution_role_intg",
-          "arn:aws:iam::${staging_account}:role/frontend_ecs_execution_role_staging",
-          "arn:aws:iam::${prod_account}:role/frontend_ecs_execution_role_prod"
+          "arn:aws:iam::${staging_account}:role/frontend_ecs_execution_role_staging"
         ]
       },
       "Action": [


### PR DESCRIPTION
The roles in these ECR access policies need to exist otherwise terraforn will fail. We took prod down so these need to come out for a bit.