### PR TITLE
Add list of muted ECR alerts to notifications lambda

### DIFF
--- a/lambda/notifications.tf
+++ b/lambda/notifications.tf
@@ -10,8 +10,9 @@ resource "aws_lambda_function" "notifications_lambda_function" {
   tags          = var.common_tags
   environment {
     variables = {
-      SLACK_WEBHOOK = data.aws_ssm_parameter.slack_webook[count.index].value
-      TO_EMAIL      = "${data.aws_ssm_parameter.notification_email_prefix[count.index].value}@nationalarchives.gov.uk"
+      SLACK_WEBHOOK         = data.aws_ssm_parameter.slack_webook[count.index].value
+      TO_EMAIL              = "${data.aws_ssm_parameter.notification_email_prefix[count.index].value}@nationalarchives.gov.uk"
+      MUTED_VULNERABILITIES = join(",", var.muted_scan_alerts)
     }
   }
 

--- a/lambda/variables.tf
+++ b/lambda/variables.tf
@@ -161,3 +161,9 @@ variable "db_admin_password" {
 variable "db_url" {
   default = ""
 }
+
+variable "muted_scan_alerts" {
+  description = "Parameter for the notification lambda listing which ECR scan alerts should be muted"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
Set an environment variable containing the provided list of muted vulnerability names. These are CVEs for which no fix is available, and which should be temporarily muted in the email and Slack alerts.