### PR TITLE
Allow notifications Lambda to get scan findings for all ECR repos

### DIFF
--- a/lambda/templates/notifications_lambda.json.tpl
+++ b/lambda/templates/notifications_lambda.json.tpl
@@ -19,6 +19,13 @@
         "arn:aws:ses:eu-west-2:${account_id}:identity/${email}",
         "arn:aws:ses:eu-west-2:${account_id}:identity/tdr-management.nationalarchives.gov.uk"
       ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "ecr:DescribeImageScanFindings",
+      "Resource": [
+        "arn:aws:ecr:eu-west-2:${account_id}:repository/*"
+      ]
     }
   ]
 }


### PR DESCRIPTION
This lets the Lambda get the details of scan results, so it can inspect the IDs of the vulnerabilities: https://github.com/nationalarchives/tdr-notifications/pull/16