### PR TITLE
Encrypt AV variables

### DIFF
--- a/lambda/api_update.tf
+++ b/lambda/api_update.tf
@@ -10,18 +10,18 @@ resource "aws_lambda_function" "lambda_api_update_function" {
   tags          = var.common_tags
   environment {
     variables = {
-      API_URL       = data.aws_kms_ciphertext.environment_vars_api_update["api_url"].ciphertext_blob
-      AUTH_URL      = data.aws_kms_ciphertext.environment_vars_api_update["auth_url"].ciphertext_blob
-      CLIENT_ID     = data.aws_kms_ciphertext.environment_vars_api_update["client_id"].ciphertext_blob
-      CLIENT_SECRET = data.aws_kms_ciphertext.environment_vars_api_update["client_secret"].ciphertext_blob
-      QUEUE_URL     = data.aws_kms_ciphertext.environment_vars_api_update["queue_url"].ciphertext_blob
+      API_URL       = aws_kms_ciphertext.environment_vars_api_update["api_url"].ciphertext_blob
+      AUTH_URL      = aws_kms_ciphertext.environment_vars_api_update["auth_url"].ciphertext_blob
+      CLIENT_ID     = aws_kms_ciphertext.environment_vars_api_update["client_id"].ciphertext_blob
+      CLIENT_SECRET = aws_kms_ciphertext.environment_vars_api_update["client_secret"].ciphertext_blob
+      QUEUE_URL     = aws_kms_ciphertext.environment_vars_api_update["queue_url"].ciphertext_blob
     }
   }
   lifecycle {
-    ignore_changes = [filename, environment]
+    ignore_changes = [filename]
   }
 }
-data "aws_kms_ciphertext" "environment_vars_api_update" {
+resource "aws_kms_ciphertext" "environment_vars_api_update" {
   for_each  = local.count_api_update == 0 ? {} : { api_url = "${var.api_url}/graphql", auth_url = var.auth_url, client_id = "tdr-backend-checks", client_secret = var.keycloak_backend_checks_client_secret, queue_url = local.api_update_queue_url }
   key_id    = var.kms_key_arn
   plaintext = each.value

--- a/lambda/api_update.tf
+++ b/lambda/api_update.tf
@@ -18,7 +18,7 @@ resource "aws_lambda_function" "lambda_api_update_function" {
     }
   }
   lifecycle {
-    ignore_changes = [filename]
+    ignore_changes = [filename, environment]
   }
 }
 data "aws_kms_ciphertext" "environment_vars_api_update" {

--- a/lambda/checksum.tf
+++ b/lambda/checksum.tf
@@ -29,7 +29,7 @@ resource "aws_lambda_function" "checksum_lambda_function" {
   }
 
   lifecycle {
-    ignore_changes = [filename]
+    ignore_changes = [filename, environment]
   }
 
   depends_on = [var.mount_target_zero, var.mount_target_one]

--- a/lambda/checksum.tf
+++ b/lambda/checksum.tf
@@ -10,10 +10,10 @@ resource "aws_lambda_function" "checksum_lambda_function" {
   tags          = var.common_tags
   environment {
     variables = {
-      INPUT_QUEUE      = data.aws_kms_ciphertext.environment_vars_checksum["input_queue"].ciphertext_blob
-      OUTPUT_QUEUE     = data.aws_kms_ciphertext.environment_vars_checksum["output_queue"].ciphertext_blob
-      CHUNK_SIZE_IN_MB = data.aws_kms_ciphertext.environment_vars_checksum["chunk_size_in_mb"].ciphertext_blob
-      ROOT_DIRECTORY   = data.aws_kms_ciphertext.environment_vars_checksum["root_directory"].ciphertext_blob
+      INPUT_QUEUE      = aws_kms_ciphertext.environment_vars_checksum["input_queue"].ciphertext_blob
+      OUTPUT_QUEUE     = aws_kms_ciphertext.environment_vars_checksum["output_queue"].ciphertext_blob
+      CHUNK_SIZE_IN_MB = aws_kms_ciphertext.environment_vars_checksum["chunk_size_in_mb"].ciphertext_blob
+      ROOT_DIRECTORY   = aws_kms_ciphertext.environment_vars_checksum["root_directory"].ciphertext_blob
     }
   }
 
@@ -29,13 +29,13 @@ resource "aws_lambda_function" "checksum_lambda_function" {
   }
 
   lifecycle {
-    ignore_changes = [filename, environment]
+    ignore_changes = [filename]
   }
 
   depends_on = [var.mount_target_zero, var.mount_target_one]
 }
 
-data "aws_kms_ciphertext" "environment_vars_checksum" {
+resource "aws_kms_ciphertext" "environment_vars_checksum" {
   for_each  = local.count_checksum == 0 ? {} : { input_queue = local.checksum_queue_url, output_queue = local.api_update_queue_url, chunk_size_in_mb = 50, root_directory = var.backend_checks_efs_root_directory_path }
   key_id    = var.kms_key_arn
   plaintext = each.value

--- a/lambda/create_db_users.tf
+++ b/lambda/create_db_users.tf
@@ -10,9 +10,9 @@ resource "aws_lambda_function" "create_db_users_lambda_function" {
   tags          = var.common_tags
   environment {
     variables = {
-      DB_ADMIN_USER     = data.aws_kms_ciphertext.environment_vars_create_db_users["db_admin_user"].ciphertext_blob
-      DB_ADMIN_PASSWORD = data.aws_kms_ciphertext.environment_vars_create_db_users["db_admin_password"].ciphertext_blob
-      DB_URL            = data.aws_kms_ciphertext.environment_vars_create_db_users["db_url"].ciphertext_blob
+      DB_ADMIN_USER     = aws_kms_ciphertext.environment_vars_create_db_users["db_admin_user"].ciphertext_blob
+      DB_ADMIN_PASSWORD = aws_kms_ciphertext.environment_vars_create_db_users["db_admin_password"].ciphertext_blob
+      DB_URL            = aws_kms_ciphertext.environment_vars_create_db_users["db_url"].ciphertext_blob
     }
   }
 
@@ -22,11 +22,11 @@ resource "aws_lambda_function" "create_db_users_lambda_function" {
   }
 
   lifecycle {
-    ignore_changes = [filename, environment]
+    ignore_changes = [filename]
   }
 }
 
-data "aws_kms_ciphertext" "environment_vars_create_db_users" {
+resource "aws_kms_ciphertext" "environment_vars_create_db_users" {
   for_each  = local.count_create_db_users == 0 ? {} : { db_admin_user = var.db_admin_user, db_admin_password = var.db_admin_password, db_url = "jdbc:postgresql://${var.db_url}:5432/consignmentapi" }
   key_id    = var.kms_key_arn
   plaintext = each.value

--- a/lambda/create_db_users.tf
+++ b/lambda/create_db_users.tf
@@ -22,7 +22,7 @@ resource "aws_lambda_function" "create_db_users_lambda_function" {
   }
 
   lifecycle {
-    ignore_changes = [filename]
+    ignore_changes = [filename, environment]
   }
 }
 

--- a/lambda/download_files.tf
+++ b/lambda/download_files.tf
@@ -34,7 +34,7 @@ resource "aws_lambda_function" "download_files_lambda_function" {
   }
 
   lifecycle {
-    ignore_changes = [filename]
+    ignore_changes = [filename, environment]
   }
 }
 

--- a/lambda/download_files.tf
+++ b/lambda/download_files.tf
@@ -10,16 +10,16 @@ resource "aws_lambda_function" "download_files_lambda_function" {
   tags          = var.common_tags
   environment {
     variables = {
-      ENVIRONMENT       = data.aws_kms_ciphertext.environment_vars_download_files["environment"].ciphertext_blob
-      INPUT_QUEUE       = data.aws_kms_ciphertext.environment_vars_download_files["input_queue"].ciphertext_blob
-      ANTIVIRUS_QUEUE   = data.aws_kms_ciphertext.environment_vars_download_files["antivirus_queue"].ciphertext_blob
-      FILE_FORMAT_QUEUE = data.aws_kms_ciphertext.environment_vars_download_files["file_format_queue"].ciphertext_blob
-      CHECKSUM_QUEUE    = data.aws_kms_ciphertext.environment_vars_download_files["checksum_queue"].ciphertext_blob
-      AUTH_URL          = data.aws_kms_ciphertext.environment_vars_download_files["auth_url"].ciphertext_blob
-      API_URL           = data.aws_kms_ciphertext.environment_vars_download_files["api_url"].ciphertext_blob
-      CLIENT_ID         = data.aws_kms_ciphertext.environment_vars_download_files["client_id"].ciphertext_blob
-      CLIENT_SECRET     = data.aws_kms_ciphertext.environment_vars_download_files["client_secret"].ciphertext_blob
-      ROOT_DIRECTORY    = data.aws_kms_ciphertext.environment_vars_download_files["root_directory"].ciphertext_blob
+      ENVIRONMENT       = aws_kms_ciphertext.environment_vars_download_files["environment"].ciphertext_blob
+      INPUT_QUEUE       = aws_kms_ciphertext.environment_vars_download_files["input_queue"].ciphertext_blob
+      ANTIVIRUS_QUEUE   = aws_kms_ciphertext.environment_vars_download_files["antivirus_queue"].ciphertext_blob
+      FILE_FORMAT_QUEUE = aws_kms_ciphertext.environment_vars_download_files["file_format_queue"].ciphertext_blob
+      CHECKSUM_QUEUE    = aws_kms_ciphertext.environment_vars_download_files["checksum_queue"].ciphertext_blob
+      AUTH_URL          = aws_kms_ciphertext.environment_vars_download_files["auth_url"].ciphertext_blob
+      API_URL           = aws_kms_ciphertext.environment_vars_download_files["api_url"].ciphertext_blob
+      CLIENT_ID         = aws_kms_ciphertext.environment_vars_download_files["client_id"].ciphertext_blob
+      CLIENT_SECRET     = aws_kms_ciphertext.environment_vars_download_files["client_secret"].ciphertext_blob
+      ROOT_DIRECTORY    = aws_kms_ciphertext.environment_vars_download_files["root_directory"].ciphertext_blob
     }
   }
   file_system_config {
@@ -34,11 +34,11 @@ resource "aws_lambda_function" "download_files_lambda_function" {
   }
 
   lifecycle {
-    ignore_changes = [filename, environment]
+    ignore_changes = [filename]
   }
 }
 
-data "aws_kms_ciphertext" "environment_vars_download_files" {
+resource "aws_kms_ciphertext" "environment_vars_download_files" {
   for_each  = local.count_download_files == 0 ? {} : { environment = local.environment, input_queue = local.download_files_queue_url, antivirus_queue = local.antivirus_queue_url, file_format_queue = local.file_format_queue_url, checksum_queue = local.checksum_queue_url, auth_url = var.auth_url, api_url = "${var.api_url}/graphql", client_id = "tdr-backend-checks", client_secret = var.backend_checks_client_secret, root_directory = var.backend_checks_efs_root_directory_path }
   key_id    = var.kms_key_arn
   plaintext = each.value

--- a/lambda/ecr_scan.tf
+++ b/lambda/ecr_scan.tf
@@ -10,7 +10,7 @@ resource "aws_lambda_function" "ecr_scan_lambda_function" {
   tags          = var.common_tags
 
   lifecycle {
-    ignore_changes = [filename, environment]
+    ignore_changes = [filename]
   }
 }
 

--- a/lambda/ecr_scan.tf
+++ b/lambda/ecr_scan.tf
@@ -10,7 +10,7 @@ resource "aws_lambda_function" "ecr_scan_lambda_function" {
   tags          = var.common_tags
 
   lifecycle {
-    ignore_changes = [filename]
+    ignore_changes = [filename, environment]
   }
 }
 

--- a/lambda/export_api_authoriser.tf
+++ b/lambda/export_api_authoriser.tf
@@ -10,16 +10,16 @@ resource "aws_lambda_function" "export_api_authoriser_lambda_function" {
   tags          = var.common_tags
   environment {
     variables = {
-      API_URL = data.aws_kms_ciphertext.environment_vars_export_api_authoriser["api_url"].ciphertext_blob
+      API_URL = aws_kms_ciphertext.environment_vars_export_api_authoriser["api_url"].ciphertext_blob
     }
   }
 
   lifecycle {
-    ignore_changes = [filename, environment]
+    ignore_changes = [filename]
   }
 }
 
-data "aws_kms_ciphertext" "environment_vars_export_api_authoriser" {
+resource "aws_kms_ciphertext" "environment_vars_export_api_authoriser" {
   for_each  = local.count_export_api_authoriser == 0 ? {} : { api_url = "${var.api_url}/graphql" }
   key_id    = var.kms_key_arn
   plaintext = each.value

--- a/lambda/export_api_authoriser.tf
+++ b/lambda/export_api_authoriser.tf
@@ -15,7 +15,7 @@ resource "aws_lambda_function" "export_api_authoriser_lambda_function" {
   }
 
   lifecycle {
-    ignore_changes = [filename]
+    ignore_changes = [filename, environment]
   }
 }
 

--- a/lambda/file_format.tf
+++ b/lambda/file_format.tf
@@ -10,10 +10,10 @@ resource "aws_lambda_function" "file_format_lambda_function" {
   tags          = var.common_tags
   environment {
     variables = {
-      ENVIRONMENT    = data.aws_kms_ciphertext.environment_vars_file_format["environment"].ciphertext_blob
-      INPUT_QUEUE    = data.aws_kms_ciphertext.environment_vars_file_format["input_queue"].ciphertext_blob
-      OUTPUT_QUEUE   = data.aws_kms_ciphertext.environment_vars_file_format["output_queue"].ciphertext_blob
-      ROOT_DIRECTORY = data.aws_kms_ciphertext.environment_vars_file_format["root_directory"].ciphertext_blob
+      ENVIRONMENT    = aws_kms_ciphertext.environment_vars_file_format["environment"].ciphertext_blob
+      INPUT_QUEUE    = aws_kms_ciphertext.environment_vars_file_format["input_queue"].ciphertext_blob
+      OUTPUT_QUEUE   = aws_kms_ciphertext.environment_vars_file_format["output_queue"].ciphertext_blob
+      ROOT_DIRECTORY = aws_kms_ciphertext.environment_vars_file_format["root_directory"].ciphertext_blob
     }
   }
   file_system_config {
@@ -28,13 +28,13 @@ resource "aws_lambda_function" "file_format_lambda_function" {
   }
 
   lifecycle {
-    ignore_changes = [filename, environment]
+    ignore_changes = [filename]
   }
 
   depends_on = [var.mount_target_zero, var.mount_target_one]
 }
 
-data "aws_kms_ciphertext" "environment_vars_file_format" {
+resource "aws_kms_ciphertext" "environment_vars_file_format" {
   for_each  = local.count_file_format == 0 ? {} : { environment = local.environment, input_queue = local.file_format_queue_url, output_queue = local.api_update_queue_url, root_directory = var.backend_checks_efs_root_directory_path }
   key_id    = var.kms_key_arn
   plaintext = each.value

--- a/lambda/file_format.tf
+++ b/lambda/file_format.tf
@@ -28,7 +28,7 @@ resource "aws_lambda_function" "file_format_lambda_function" {
   }
 
   lifecycle {
-    ignore_changes = [filename]
+    ignore_changes = [filename, environment]
   }
 
   depends_on = [var.mount_target_zero, var.mount_target_one]

--- a/lambda/log_data.tf
+++ b/lambda/log_data.tf
@@ -55,16 +55,16 @@ resource "aws_lambda_function" "log_data_lambda" {
 
   environment {
     variables = {
-      TARGET_S3_BUCKET = data.aws_kms_ciphertext.environment_vars_log_data["target_s3_bucket"].ciphertext_blob
+      TARGET_S3_BUCKET = aws_kms_ciphertext.environment_vars_log_data["target_s3_bucket"].ciphertext_blob
     }
   }
 
   lifecycle {
-    ignore_changes = [last_modified, environment]
+    ignore_changes = [last_modified]
   }
 }
 
-data "aws_kms_ciphertext" "environment_vars_log_data" {
+resource "aws_kms_ciphertext" "environment_vars_log_data" {
   for_each  = local.count_log_data == 0 ? {} : { target_s3_bucket = var.target_s3_bucket }
   key_id    = var.kms_key_arn
   plaintext = each.value

--- a/lambda/notifications.tf
+++ b/lambda/notifications.tf
@@ -10,18 +10,18 @@ resource "aws_lambda_function" "notifications_lambda_function" {
   tags          = var.common_tags
   environment {
     variables = {
-      SLACK_WEBHOOK         = data.aws_kms_ciphertext.environment_vars_notifications["slack_webhook"].ciphertext_blob
-      TO_EMAIL              = data.aws_kms_ciphertext.environment_vars_notifications["to_email"].ciphertext_blob
-      MUTED_VULNERABILITIES = data.aws_kms_ciphertext.environment_vars_notifications["muted_vulnerabilities"].ciphertext_blob
+      SLACK_WEBHOOK         = aws_kms_ciphertext.environment_vars_notifications["slack_webhook"].ciphertext_blob
+      TO_EMAIL              = aws_kms_ciphertext.environment_vars_notifications["to_email"].ciphertext_blob
+      MUTED_VULNERABILITIES = aws_kms_ciphertext.environment_vars_notifications["muted_vulnerabilities"].ciphertext_blob
     }
   }
 
   lifecycle {
-    ignore_changes = [filename, environment]
+    ignore_changes = [filename]
   }
 }
 
-data "aws_kms_ciphertext" "environment_vars_notifications" {
+resource "aws_kms_ciphertext" "environment_vars_notifications" {
   for_each = local.count_notifications == 0 ? {} : { slack_webhook = data.aws_ssm_parameter.slack_webook[0].value, to_email = "${data.aws_ssm_parameter.notification_email_prefix[0].value}@nationalarchives.gov.uk", muted_vulnerabilities = join(",", var.muted_scan_alerts) }
   # This lambda is created by the tdr-terraform-backend project as it only exists in the management account so we can't use any KMS keys
   # created by the terraform environments project as they won't exist when we first run the backend project.

--- a/lambda/notifications.tf
+++ b/lambda/notifications.tf
@@ -17,7 +17,7 @@ resource "aws_lambda_function" "notifications_lambda_function" {
   }
 
   lifecycle {
-    ignore_changes = [filename]
+    ignore_changes = [filename, environment]
   }
 }
 

--- a/lambda/yara_av.tf
+++ b/lambda/yara_av.tf
@@ -10,10 +10,10 @@ resource "aws_lambda_function" "lambda_function" {
   tags          = var.common_tags
   environment {
     variables = {
-      ENVIRONMENT    = data.aws_kms_ciphertext.environment_vars_yara_av["environment"].ciphertext_blob
-      ROOT_DIRECTORY = data.aws_kms_ciphertext.environment_vars_yara_av["root_directory"].ciphertext_blob
-      INPUT_QUEUE    = data.aws_kms_ciphertext.environment_vars_yara_av["input_queue"].ciphertext_blob
-      OUTPUT_QUEUE   = data.aws_kms_ciphertext.environment_vars_yara_av["output_queue"].ciphertext_blob
+      ENVIRONMENT    = aws_kms_ciphertext.environment_vars_yara_av["environment"].ciphertext_blob
+      ROOT_DIRECTORY = aws_kms_ciphertext.environment_vars_yara_av["root_directory"].ciphertext_blob
+      INPUT_QUEUE    = aws_kms_ciphertext.environment_vars_yara_av["input_queue"].ciphertext_blob
+      OUTPUT_QUEUE   = aws_kms_ciphertext.environment_vars_yara_av["output_queue"].ciphertext_blob
     }
   }
 
@@ -29,13 +29,13 @@ resource "aws_lambda_function" "lambda_function" {
   }
 
   lifecycle {
-    ignore_changes = [filename, environment]
+    ignore_changes = [filename]
   }
 
   depends_on = [var.mount_target_zero, var.mount_target_one]
 }
 
-data "aws_kms_ciphertext" "environment_vars_yara_av" {
+resource "aws_kms_ciphertext" "environment_vars_yara_av" {
   for_each  = local.count_av_yara == 0 ? {} : { environment = local.environment, root_directory = var.backend_checks_efs_root_directory_path, input_queue = local.antivirus_queue_url, output_queue = local.api_update_queue_url }
   key_id    = var.kms_key_arn
   plaintext = each.value

--- a/lambda/yara_av.tf
+++ b/lambda/yara_av.tf
@@ -10,10 +10,10 @@ resource "aws_lambda_function" "lambda_function" {
   tags          = var.common_tags
   environment {
     variables = {
-      ENVIRONMENT    = local.environment
-      ROOT_DIRECTORY = var.backend_checks_efs_root_directory_path
-      INPUT_QUEUE    = local.antivirus_queue_url
-      OUTPUT_QUEUE   = local.api_update_queue_url
+      ENVIRONMENT    = data.aws_kms_ciphertext.environment_vars_yara_av["environment"].ciphertext_blob
+      ROOT_DIRECTORY = data.aws_kms_ciphertext.environment_vars_yara_av["root_directory"].ciphertext_blob
+      INPUT_QUEUE    = data.aws_kms_ciphertext.environment_vars_yara_av["input_queue"].ciphertext_blob
+      OUTPUT_QUEUE   = data.aws_kms_ciphertext.environment_vars_yara_av["output_queue"].ciphertext_blob
     }
   }
 
@@ -29,7 +29,7 @@ resource "aws_lambda_function" "lambda_function" {
   }
 
   lifecycle {
-    ignore_changes = [filename]
+    ignore_changes = [filename, environment]
   }
 
   depends_on = [var.mount_target_zero, var.mount_target_one]


### PR DESCRIPTION
- Encrypt the lambda av variables - I missed this one off the original PR.
- Set environment to ignore - If you don't, terraform will report a change every time you run it as
each call to kms to encrypt the variables gives a slightly different
encrypted text and I can't find any way around it other than to ignore
the environment variables.
