### PR TITLE
Increase authoriser memory

### DIFF
--- a/lambda/export_api_authoriser.tf
+++ b/lambda/export_api_authoriser.tf
@@ -6,7 +6,7 @@ resource "aws_lambda_function" "export_api_authoriser_lambda_function" {
   runtime       = "java11"
   filename      = "${path.module}/functions/export-authoriser.jar"
   timeout       = 10
-  memory_size   = 1024
+  memory_size   = 4096
   tags          = var.common_tags
   environment {
     variables = {


### PR DESCRIPTION
The export api authoriser lambda is taking longer than 10 seconds since
we added the encrypted environment variables.
It's possible that this is caused by a high cpu load when it's
decrypting and as memory in lambda is linked to cpu, increasing the
memory should increase the cpu and speed it up a bit.
