### PR TITLE
Add create keycloak user lambda

### DIFF
--- a/lambda/create_db_users.tf
+++ b/lambda/create_db_users.tf
@@ -13,6 +13,7 @@ resource "aws_lambda_function" "create_db_users_lambda_function" {
       DB_ADMIN_USER     = aws_kms_ciphertext.environment_vars_create_db_users["db_admin_user"].ciphertext_blob
       DB_ADMIN_PASSWORD = aws_kms_ciphertext.environment_vars_create_db_users["db_admin_password"].ciphertext_blob
       DB_URL            = aws_kms_ciphertext.environment_vars_create_db_users["db_url"].ciphertext_blob
+      DATABASE_NAME = aws_kms_ciphertext.environment_vars_create_db_users["database_name"].ciphertext_blob
     }
   }
 
@@ -27,7 +28,7 @@ resource "aws_lambda_function" "create_db_users_lambda_function" {
 }
 
 resource "aws_kms_ciphertext" "environment_vars_create_db_users" {
-  for_each  = local.count_create_db_users == 0 ? {} : { db_admin_user = var.db_admin_user, db_admin_password = var.db_admin_password, db_url = "jdbc:postgresql://${var.db_url}:5432/consignmentapi" }
+  for_each  = local.count_create_db_users == 0 ? {} : { db_admin_user = var.db_admin_user, db_admin_password = var.db_admin_password, db_url = "jdbc:postgresql://${var.db_url}:5432/consignmentapi", database_name = "consignmentapi" }
   key_id    = var.kms_key_arn
   plaintext = each.value
   context   = { "LambdaFunctionName" = local.create_db_users_function_name }

--- a/lambda/create_db_users.tf
+++ b/lambda/create_db_users.tf
@@ -13,7 +13,7 @@ resource "aws_lambda_function" "create_db_users_lambda_function" {
       DB_ADMIN_USER     = aws_kms_ciphertext.environment_vars_create_db_users["db_admin_user"].ciphertext_blob
       DB_ADMIN_PASSWORD = aws_kms_ciphertext.environment_vars_create_db_users["db_admin_password"].ciphertext_blob
       DB_URL            = aws_kms_ciphertext.environment_vars_create_db_users["db_url"].ciphertext_blob
-      DATABASE_NAME = aws_kms_ciphertext.environment_vars_create_db_users["database_name"].ciphertext_blob
+      DATABASE_NAME     = aws_kms_ciphertext.environment_vars_create_db_users["database_name"].ciphertext_blob
     }
   }
 

--- a/lambda/create_keycloak_db_user.tf
+++ b/lambda/create_keycloak_db_user.tf
@@ -13,7 +13,7 @@ resource "aws_lambda_function" "create_keycloak_db_user_lambda_function" {
       DB_ADMIN_USER     = aws_kms_ciphertext.environment_vars_create_keycloak_db_user["db_admin_user"].ciphertext_blob
       DB_ADMIN_PASSWORD = aws_kms_ciphertext.environment_vars_create_keycloak_db_user["db_admin_password"].ciphertext_blob
       DB_URL            = aws_kms_ciphertext.environment_vars_create_keycloak_db_user["db_url"].ciphertext_blob
-      DATABASE_NAME = aws_kms_ciphertext.environment_vars_create_keycloak_db_user["database_name"].ciphertext_blob
+      DATABASE_NAME     = aws_kms_ciphertext.environment_vars_create_keycloak_db_user["database_name"].ciphertext_blob
     }
   }
 
@@ -72,7 +72,7 @@ resource "aws_security_group" "create_keycloak_db_user_lambda" {
   }
 
   tags = merge(
-  var.common_tags,
-  map("Name", "${var.project}-create-keycloak-db-users-lambda-security-group")
+    var.common_tags,
+    map("Name", "${var.project}-create-keycloak-db-users-lambda-security-group")
   )
 }

--- a/lambda/create_keycloak_db_user.tf
+++ b/lambda/create_keycloak_db_user.tf
@@ -1,0 +1,78 @@
+resource "aws_lambda_function" "create_keycloak_db_user_lambda_function" {
+  count         = local.count_create_keycloak_db_user
+  function_name = local.create_keycloak_db_user_function_name
+  handler       = "uk.gov.nationalarchives.db.users.Lambda::process"
+  role          = aws_iam_role.create_keycloak_db_user_lambda_iam_role.*.arn[0]
+  runtime       = "java11"
+  filename      = "${path.module}/functions/create-db-users.jar"
+  timeout       = 180
+  memory_size   = 1024
+  tags          = var.common_tags
+  environment {
+    variables = {
+      DB_ADMIN_USER     = aws_kms_ciphertext.environment_vars_create_keycloak_db_user["db_admin_user"].ciphertext_blob
+      DB_ADMIN_PASSWORD = aws_kms_ciphertext.environment_vars_create_keycloak_db_user["db_admin_password"].ciphertext_blob
+      DB_URL            = aws_kms_ciphertext.environment_vars_create_keycloak_db_user["db_url"].ciphertext_blob
+      DATABASE_NAME = aws_kms_ciphertext.environment_vars_create_keycloak_db_user["database_name"].ciphertext_blob
+    }
+  }
+
+  vpc_config {
+    subnet_ids         = var.private_subnet_ids
+    security_group_ids = aws_security_group.create_keycloak_db_user_lambda.*.id
+  }
+
+  lifecycle {
+    ignore_changes = [filename]
+  }
+}
+
+resource "aws_kms_ciphertext" "environment_vars_create_keycloak_db_user" {
+  for_each  = local.count_create_keycloak_db_user == 0 ? {} : { db_admin_user = var.keycloak_admin_user, db_admin_password = var.keycloak_admin_password, db_url = "jdbc:postgresql://${var.keycloak_db_url}:5432/keycloak", database_name = "keycloak" }
+  key_id    = var.kms_key_arn
+  plaintext = each.value
+  context   = { "LambdaFunctionName" = local.create_keycloak_db_user_function_name }
+}
+
+resource "aws_cloudwatch_log_group" "create_keycloak_db_user_lambda_log_group" {
+  count = local.count_create_keycloak_db_user
+  name  = "/aws/lambda/${aws_lambda_function.create_keycloak_db_user_lambda_function.*.function_name[0]}"
+  tags  = var.common_tags
+}
+
+resource "aws_iam_policy" "create_keycloak_db_user_lambda_policy" {
+  count  = local.count_create_keycloak_db_user
+  policy = templatefile("${path.module}/templates/create_keycloak_db_user_lambda.json.tpl", { environment = local.environment, account_id = data.aws_caller_identity.current.account_id, kms_arn = var.kms_key_arn })
+  name   = "${upper(var.project)}CreateKeycloakDbUserPolicy${title(local.environment)}"
+}
+
+resource "aws_iam_role" "create_keycloak_db_user_lambda_iam_role" {
+  count              = local.count_create_keycloak_db_user
+  assume_role_policy = templatefile("${path.module}/templates/lambda_assume_role.json.tpl", {})
+  name               = "${upper(var.project)}CreateKeycloakDbUserRole${title(local.environment)}"
+}
+
+resource "aws_iam_role_policy_attachment" "create_keycloak_db_user_lambda_role_policy" {
+  count      = local.count_create_keycloak_db_user
+  policy_arn = aws_iam_policy.create_keycloak_db_user_lambda_policy.*.arn[0]
+  role       = aws_iam_role.create_keycloak_db_user_lambda_iam_role.*.name[0]
+}
+
+resource "aws_security_group" "create_keycloak_db_user_lambda" {
+  count       = local.count_create_keycloak_db_user
+  name        = "create-keycloak-db-user-lambda-security-group"
+  description = "Allow access to the keycloak database"
+  vpc_id      = var.vpc_id
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(
+  var.common_tags,
+  map("Name", "${var.project}-create-keycloak-db-users-lambda-security-group")
+  )
+}

--- a/lambda/create_keycloak_db_user.tf
+++ b/lambda/create_keycloak_db_user.tf
@@ -14,6 +14,7 @@ resource "aws_lambda_function" "create_keycloak_db_user_lambda_function" {
       DB_ADMIN_PASSWORD = aws_kms_ciphertext.environment_vars_create_keycloak_db_user["db_admin_password"].ciphertext_blob
       DB_URL            = aws_kms_ciphertext.environment_vars_create_keycloak_db_user["db_url"].ciphertext_blob
       DATABASE_NAME     = aws_kms_ciphertext.environment_vars_create_keycloak_db_user["database_name"].ciphertext_blob
+      KEYCLOAK_PASSWORD = aws_kms_ciphertext.environment_vars_create_keycloak_db_user["keycloak_password"].ciphertext_blob
     }
   }
 
@@ -28,7 +29,7 @@ resource "aws_lambda_function" "create_keycloak_db_user_lambda_function" {
 }
 
 resource "aws_kms_ciphertext" "environment_vars_create_keycloak_db_user" {
-  for_each  = local.count_create_keycloak_db_user == 0 ? {} : { db_admin_user = var.keycloak_admin_user, db_admin_password = var.keycloak_admin_password, db_url = "jdbc:postgresql://${var.keycloak_db_url}:5432/keycloak", database_name = "keycloak" }
+  for_each  = local.count_create_keycloak_db_user == 0 ? {} : { db_admin_user = var.db_admin_user, db_admin_password = var.db_admin_password, db_url = "jdbc:postgresql://${var.db_url}:5432/keycloak", database_name = "keycloak", keycloak_password = var.keycloak_password }
   key_id    = var.kms_key_arn
   plaintext = each.value
   context   = { "LambdaFunctionName" = local.create_keycloak_db_user_function_name }

--- a/lambda/locals.tf
+++ b/lambda/locals.tf
@@ -12,10 +12,12 @@ locals {
   count_ecr_scan                      = var.apply_resource == true && var.lambda_ecr_scan == true ? 1 : 0
   count_efs                           = var.apply_resource == true && var.use_efs ? 1 : 0
   count_create_db_users               = var.apply_resource == true && var.lambda_create_db_users ? 1 : 0
+  count_create_keycloak_db_user               = var.apply_resource == true && var.lambda_create_keycloak_db_users ? 1 : 0
   count_export_api_authoriser         = var.apply_resource == true && var.lambda_export_authoriser == true ? 1 : 0
   api_update_function_name            = "${var.project}-api-update-${local.environment}"
   checksum_function_name              = "${var.project}-checksum-${local.environment}"
   create_db_users_function_name       = "${var.project}-create-db-users-${local.environment}"
+  create_keycloak_db_user_function_name = "${var.project}-create-keycloak-db-user-${local.environment}"
   download_files_function_name        = "${var.project}-download-files-${local.environment}"
   export_api_authoriser_function_name = "${var.project}-export-api-authoriser-${local.environment}"
   file_format_function_name           = "${var.project}-file-format-${local.environment}"

--- a/lambda/locals.tf
+++ b/lambda/locals.tf
@@ -1,39 +1,39 @@
 locals {
-  workspace                           = lower(terraform.workspace)
-  environment                         = local.workspace == "default" ? "mgmt" : local.workspace
-  count_av_yara                       = var.apply_resource == true && var.lambda_yara_av == true ? 1 : 0
-  count_checksum                      = var.apply_resource == true && var.lambda_checksum == true ? 1 : 0
-  count_log_data                      = var.apply_resource == true && var.lambda_log_data == true ? 1 : 0
-  count_api_update                    = var.apply_resource && var.lambda_api_update == true ? 1 : 0
-  count_file_format                   = var.apply_resource && var.lambda_file_format == true ? 1 : 0
-  count_log_data_mgmt                 = var.apply_resource == true && var.lambda_log_data == true && local.environment == "mgmt" ? 1 : 0
-  count_download_files                = var.apply_resource == true && var.lambda_download_files == true ? 1 : 0
-  count_notifications                 = var.apply_resource == true && var.lambda_ecr_scan_notifications == true ? 1 : 0
-  count_ecr_scan                      = var.apply_resource == true && var.lambda_ecr_scan == true ? 1 : 0
-  count_efs                           = var.apply_resource == true && var.use_efs ? 1 : 0
-  count_create_db_users               = var.apply_resource == true && var.lambda_create_db_users ? 1 : 0
-  count_create_keycloak_db_user               = var.apply_resource == true && var.lambda_create_keycloak_db_users ? 1 : 0
-  count_export_api_authoriser         = var.apply_resource == true && var.lambda_export_authoriser == true ? 1 : 0
-  api_update_function_name            = "${var.project}-api-update-${local.environment}"
-  checksum_function_name              = "${var.project}-checksum-${local.environment}"
-  create_db_users_function_name       = "${var.project}-create-db-users-${local.environment}"
+  workspace                             = lower(terraform.workspace)
+  environment                           = local.workspace == "default" ? "mgmt" : local.workspace
+  count_av_yara                         = var.apply_resource == true && var.lambda_yara_av == true ? 1 : 0
+  count_checksum                        = var.apply_resource == true && var.lambda_checksum == true ? 1 : 0
+  count_log_data                        = var.apply_resource == true && var.lambda_log_data == true ? 1 : 0
+  count_api_update                      = var.apply_resource && var.lambda_api_update == true ? 1 : 0
+  count_file_format                     = var.apply_resource && var.lambda_file_format == true ? 1 : 0
+  count_log_data_mgmt                   = var.apply_resource == true && var.lambda_log_data == true && local.environment == "mgmt" ? 1 : 0
+  count_download_files                  = var.apply_resource == true && var.lambda_download_files == true ? 1 : 0
+  count_notifications                   = var.apply_resource == true && var.lambda_ecr_scan_notifications == true ? 1 : 0
+  count_ecr_scan                        = var.apply_resource == true && var.lambda_ecr_scan == true ? 1 : 0
+  count_efs                             = var.apply_resource == true && var.use_efs ? 1 : 0
+  count_create_db_users                 = var.apply_resource == true && var.lambda_create_db_users ? 1 : 0
+  count_create_keycloak_db_user         = var.apply_resource == true && var.lambda_create_keycloak_db_users ? 1 : 0
+  count_export_api_authoriser           = var.apply_resource == true && var.lambda_export_authoriser == true ? 1 : 0
+  api_update_function_name              = "${var.project}-api-update-${local.environment}"
+  checksum_function_name                = "${var.project}-checksum-${local.environment}"
+  create_db_users_function_name         = "${var.project}-create-db-users-${local.environment}"
   create_keycloak_db_user_function_name = "${var.project}-create-keycloak-db-user-${local.environment}"
-  download_files_function_name        = "${var.project}-download-files-${local.environment}"
-  export_api_authoriser_function_name = "${var.project}-export-api-authoriser-${local.environment}"
-  file_format_function_name           = "${var.project}-file-format-${local.environment}"
-  log_data_function_name              = "${var.project}-log-data-${local.environment}"
-  notifications_function_name         = "${var.project}-notifications-${local.environment}"
-  yara_av_function_name               = "${var.project}-yara-av-${local.environment}"
-  api_update_queue_name               = "${var.project}-api-update-${local.environment}"
-  api_update_queue                    = "arn:aws:sqs:${var.region}:${data.aws_caller_identity.current.account_id}:${local.api_update_queue_name}"
-  api_update_queue_url                = "https://sqs.${var.region}.amazonaws.com/${data.aws_caller_identity.current.account_id}/${local.api_update_queue_name}"
-  antivirus_queue                     = "arn:aws:sqs:${var.region}:${data.aws_caller_identity.current.account_id}:${var.project}-antivirus-${local.environment}"
-  antivirus_queue_url                 = "https://sqs.${var.region}.amazonaws.com/${data.aws_caller_identity.current.account_id}/${var.project}-antivirus-${local.environment}"
-  checksum_queue                      = "arn:aws:sqs:${var.region}:${data.aws_caller_identity.current.account_id}:${var.project}-checksum-${local.environment}"
-  checksum_queue_url                  = "https://sqs.${var.region}.amazonaws.com/${data.aws_caller_identity.current.account_id}/${var.project}-checksum-${local.environment}"
-  download_files_queue                = "arn:aws:sqs:${var.region}:${data.aws_caller_identity.current.account_id}:${var.project}-download-files-${local.environment}"
-  download_files_queue_url            = "https://sqs.${var.region}.amazonaws.com/${data.aws_caller_identity.current.account_id}/${var.project}-download-files-${local.environment}"
-  file_format_queue                   = "arn:aws:sqs:${var.region}:${data.aws_caller_identity.current.account_id}:${var.project}-file-format-${local.environment}"
-  file_format_queue_url               = "https://sqs.${var.region}.amazonaws.com/${data.aws_caller_identity.current.account_id}/${var.project}-file-format-${local.environment}"
-  export_api_authoriser_arn           = var.apply_resource == true && var.lambda_export_authoriser == true && length(aws_lambda_function.export_api_authoriser_lambda_function) > 0 ? aws_lambda_function.export_api_authoriser_lambda_function.*.arn[0] : ""
+  download_files_function_name          = "${var.project}-download-files-${local.environment}"
+  export_api_authoriser_function_name   = "${var.project}-export-api-authoriser-${local.environment}"
+  file_format_function_name             = "${var.project}-file-format-${local.environment}"
+  log_data_function_name                = "${var.project}-log-data-${local.environment}"
+  notifications_function_name           = "${var.project}-notifications-${local.environment}"
+  yara_av_function_name                 = "${var.project}-yara-av-${local.environment}"
+  api_update_queue_name                 = "${var.project}-api-update-${local.environment}"
+  api_update_queue                      = "arn:aws:sqs:${var.region}:${data.aws_caller_identity.current.account_id}:${local.api_update_queue_name}"
+  api_update_queue_url                  = "https://sqs.${var.region}.amazonaws.com/${data.aws_caller_identity.current.account_id}/${local.api_update_queue_name}"
+  antivirus_queue                       = "arn:aws:sqs:${var.region}:${data.aws_caller_identity.current.account_id}:${var.project}-antivirus-${local.environment}"
+  antivirus_queue_url                   = "https://sqs.${var.region}.amazonaws.com/${data.aws_caller_identity.current.account_id}/${var.project}-antivirus-${local.environment}"
+  checksum_queue                        = "arn:aws:sqs:${var.region}:${data.aws_caller_identity.current.account_id}:${var.project}-checksum-${local.environment}"
+  checksum_queue_url                    = "https://sqs.${var.region}.amazonaws.com/${data.aws_caller_identity.current.account_id}/${var.project}-checksum-${local.environment}"
+  download_files_queue                  = "arn:aws:sqs:${var.region}:${data.aws_caller_identity.current.account_id}:${var.project}-download-files-${local.environment}"
+  download_files_queue_url              = "https://sqs.${var.region}.amazonaws.com/${data.aws_caller_identity.current.account_id}/${var.project}-download-files-${local.environment}"
+  file_format_queue                     = "arn:aws:sqs:${var.region}:${data.aws_caller_identity.current.account_id}:${var.project}-file-format-${local.environment}"
+  file_format_queue_url                 = "https://sqs.${var.region}.amazonaws.com/${data.aws_caller_identity.current.account_id}/${var.project}-file-format-${local.environment}"
+  export_api_authoriser_arn             = var.apply_resource == true && var.lambda_export_authoriser == true && length(aws_lambda_function.export_api_authoriser_lambda_function) > 0 ? aws_lambda_function.export_api_authoriser_lambda_function.*.arn[0] : ""
 }

--- a/lambda/outputs.tf
+++ b/lambda/outputs.tf
@@ -29,3 +29,8 @@ output "export_api_authoriser_arn" {
 output "create_users_lambda_security_group_id" {
   value = aws_security_group.create_db_users_lambda.*.id
 }
+
+output "create_keycloak_user_lambda_security_group" {
+  value = aws_security_group.create_keycloak_db_user_lambda.*.id
+}
+

--- a/lambda/templates/create_keycloak_db_user_lambda.json.tpl
+++ b/lambda/templates/create_keycloak_db_user_lambda.json.tpl
@@ -1,0 +1,33 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": [
+        "arn:aws:logs:eu-west-2:${account_id}:log-group:/aws/lambda/-create-keycloak-db-user-${environment}",
+        "arn:aws:logs:eu-west-2:${account_id}:log-group:/aws/lambda/-create-keycloak-db-user-${environment}:log-stream:*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateNetworkInterface",
+        "ec2:DeleteNetworkInterface",
+        "ec2:DescribeNetworkInterfaces"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "DecryptEnvVar",
+      "Effect": "Allow",
+      "Action": [
+        "kms:Decrypt"
+      ],
+      "Resource": "${kms_arn}"
+    }
+  ]
+}

--- a/lambda/variables.tf
+++ b/lambda/variables.tf
@@ -172,3 +172,19 @@ variable "kms_key_arn" {
   default     = ""
   description = "The KMS arn to encrypt environment variables. Not all lambdas need this so it has a default"
 }
+
+variable "keycloak_admin_user" {
+  default = ""
+}
+
+variable "keycloak_admin_password" {
+  default = ""
+}
+
+variable "keycloak_db_url" {
+  default = ""
+}
+
+variable "lambda_create_keycloak_db_users" {
+  default = false
+}

--- a/lambda/variables.tf
+++ b/lambda/variables.tf
@@ -176,3 +176,7 @@ variable "kms_key_arn" {
 variable "lambda_create_keycloak_db_users" {
   default = false
 }
+
+variable "keycloak_password" {
+  default = ""
+}

--- a/lambda/variables.tf
+++ b/lambda/variables.tf
@@ -173,18 +173,6 @@ variable "kms_key_arn" {
   description = "The KMS arn to encrypt environment variables. Not all lambdas need this so it has a default"
 }
 
-variable "keycloak_admin_user" {
-  default = ""
-}
-
-variable "keycloak_admin_password" {
-  default = ""
-}
-
-variable "keycloak_db_url" {
-  default = ""
-}
-
 variable "lambda_create_keycloak_db_users" {
   default = false
 }


### PR DESCRIPTION
I've added a new lambda to create the keycloak database user. This goes into the keycloak VPC.
There's a PR here to update the create-db-users code to create the keycloak user as well https://github.com/nationalarchives/tdr-create-db-users/pull/4
I've also added in a DATABASE_NAME environment variable to the existing create-db-users lambda as this is how the lambda determines which users to create.