### PR TITLE
Switch default KMS policy to root-only access

### DIFF
--- a/kms/variables.tf
+++ b/kms/variables.tf
@@ -16,5 +16,5 @@ variable "environment" {
 
 variable "key_policy" {
   description = "key policy within templates folder"
-  default     = "message_system_access"
+  default     = "root_access"
 }


### PR DESCRIPTION
Make the default policy the one that grants access to the root
account: https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam

tdr-terraform-environments needs to use a non-default policy, but it has already been switched to a specific policy in https://github.com/nationalarchives/tdr-terraform-environments/pull/133

Marking this as a draft PR until that environments PR has been merged.