### PR TITLE
Switch user to migrations_user and grant permissions.

### DIFF
--- a/ec2/templates/user_data_postgres.sh.tpl
+++ b/ec2/templates/user_data_postgres.sh.tpl
@@ -7,6 +7,8 @@ GRANT CONNECT ON DATABASE consignmentapi TO bastion_user;
 GRANT USAGE ON SCHEMA public TO bastion_user;
 GRANT rds_iam TO bastion_user;
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO bastion_user;
+SET ROLE migrations_user;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO bastion_user;
 EOM
 cat /home/ssm-user/create-user | PGPASSWORD=${db_password} psql -h ${db_host} -U ${db_username} -d consignmentapi | true
 cat <<\EOF >> /home/ssm-user/connect.sh


### PR DESCRIPTION
Some of the newer tables are created by the migrations user which the admin user doesn't have permission to grant read rights to.
We need to switch to the miagrations_user role and grant select permissions on all tables to the bastion user can see them.
