### PR TITLE
Revert "Use system param to get email for ses module."

### DIFF
--- a/ses/data.tf
+++ b/ses/data.tf
@@ -1,3 +1,0 @@
-data "aws_ssm_parameter" "notification_email_prefix" {
-  name = "/mgmt/notification/email/prefix"
-}

--- a/ses/locals.tf
+++ b/ses/locals.tf
@@ -1,4 +1,3 @@
 locals {
   domain = var.environment_full_name == "production" ? "${var.project}.${var.domain}" : "${var.project}-${var.environment_full_name}.${var.domain}"
-  email  = var.email_address == "" ? data.aws_ssm_parameter.notification_email_prefix.value : var.email_address
 }

--- a/ses/main.tf
+++ b/ses/main.tf
@@ -35,6 +35,6 @@ resource "aws_route53_record" "amazonses_dkim_record" {
 }
 
 resource "aws_ses_email_identity" "email_address" {
-  email = "${local.email}@${var.domain}"
+  email = "${var.email_address}@${var.domain}"
 }
 

--- a/ses/variables.tf
+++ b/ses/variables.tf
@@ -13,7 +13,7 @@ variable "domain" {
 
 variable "email_address" {
   description = "address prefix, e.g. secops"
-  default     = ""
+  default     = "tdr-secops"
 }
 
 variable "hosted_zone_id" {


### PR DESCRIPTION
This reverts commit 423c6c4665893360b2488b8b479bccb06d229659.

Fetching the default email address from the parameter store only worked in the mgmt account. In other environments, the parameter didn't exist, so any script that depended on the SES module failed.