### PR TITLE
Reset Grafana server protocol to http

### DIFF
--- a/ecs/templates/grafana_build.json.tpl
+++ b/ecs/templates/grafana_build.json.tpl
@@ -48,7 +48,7 @@
       },
       {
         "name": "GF_SERVER_PROTOCOL",
-        "value": "https"
+        "value": "http"
       }
     ],
     "networkMode": "awsvpc",


### PR DESCRIPTION
Setting the protocol to https requires a certificate

Difficult to run ECS task on https

Adding redirect rules as alternative