### PR TITLE
Remove temporary changes.

### DIFF
--- a/ec2/main.tf
+++ b/ec2/main.tf
@@ -19,10 +19,6 @@ resource "aws_instance" "instance" {
       "Name", "${var.name}-ec2-instance-${var.environment}",
     )
   )
-
-  lifecycle {
-    ignore_changes = [ami]
-  }
 }
 
 resource "aws_key_pair" "bastion_key_pair" {

--- a/waf/main.tf
+++ b/waf/main.tf
@@ -10,10 +10,6 @@ resource "aws_wafregional_ipset" "trusted" {
       value = ip.value
     }
   }
-  ip_set_descriptor {
-    type  = "IPV6"
-    value = "2001:0920:306a:0000:0000:0000:0000:0000/48"
-  }
 }
 
 resource "aws_wafregional_byte_match_set" "restricted_uri" {


### PR DESCRIPTION
I added these while I was building Jenkins to prevent the AMI being
built and to add in the manual IP address for the pen testers. I
shouldn't have committed it so I'm reverting the changes here.
