### PR TITLE
Explicitly state root url

### DIFF
--- a/ecs/grafana_build.tf
+++ b/ecs/grafana_build.tf
@@ -71,7 +71,6 @@ resource "aws_ecs_task_definition" "grafana_task" {
       domain_name            = var.domain_name
       log_group_name         = aws_cloudwatch_log_group.grafana_build_log_group[count.index].name
       project                = var.project
-      //Protocol set to 'http' with redirect to 'https' due to difficulties running ECS task on 'https'
       server_protocol        = "http"
     }
   )

--- a/ecs/grafana_build.tf
+++ b/ecs/grafana_build.tf
@@ -71,6 +71,8 @@ resource "aws_ecs_task_definition" "grafana_task" {
       domain_name            = var.domain_name
       log_group_name         = aws_cloudwatch_log_group.grafana_build_log_group[count.index].name
       project                = var.project
+      //Protocol set to 'http' with redirect to 'https' due to difficulties running ECS task on 'https'
+      server_protocol        = "http"
     }
   )
   task_role_arn = aws_iam_role.grafana_ecs_task[count.index].arn

--- a/ecs/templates/grafana_build.json.tpl
+++ b/ecs/templates/grafana_build.json.tpl
@@ -52,7 +52,7 @@
       },
       {
         "name": "GF_SERVER_ROOT_URL",
-        "value": "${server_protocol}://${domain_name}"
+        "value": "https://${domain_name}"
       }
     ],
     "networkMode": "awsvpc",

--- a/ecs/templates/grafana_build.json.tpl
+++ b/ecs/templates/grafana_build.json.tpl
@@ -48,7 +48,11 @@
       },
       {
         "name": "GF_SERVER_PROTOCOL",
-        "value": "http"
+        "value": "{server_protocol}"
+      },
+      {
+        "name": "GF_SERVER_ROOT_URL",
+        "value": "${server_protocol}://${domain_name}"
       }
     ],
     "networkMode": "awsvpc",

--- a/ecs/templates/grafana_build.json.tpl
+++ b/ecs/templates/grafana_build.json.tpl
@@ -48,7 +48,7 @@
       },
       {
         "name": "GF_SERVER_PROTOCOL",
-        "value": "{server_protocol}"
+        "value": "${server_protocol}"
       },
       {
         "name": "GF_SERVER_ROOT_URL",


### PR DESCRIPTION
Grafana defaults to the root url to a construction of protocol, domain and port

Change this to protocol and domain, as having port causes broken links in Alerts