### PR TITLE
TDR-1146 TDR-1147 Enable deletion protection and drop invalid headers on ALB

### DIFF
--- a/alb/main.tf
+++ b/alb/main.tf
@@ -10,6 +10,7 @@ resource "aws_alb" "alb_module" {
   }
 
   enable_deletion_protection = true
+  drop_invalid_header_fields = true
 
   tags = merge(
     var.common_tags,

--- a/alb/main.tf
+++ b/alb/main.tf
@@ -9,6 +9,8 @@ resource "aws_alb" "alb_module" {
     enabled = true
   }
 
+  enable_deletion_protection = true
+
   tags = merge(
     var.common_tags,
     map("Name", "${var.project}-${var.function}-${var.environment}")


### PR DESCRIPTION
This is from the pen test where they advised we should have deletion
protection on the load balancer.
As everything is using the terraform-modules, this change will apply to
all the load balancers.
