### PR TITLE
Add two file check queue policies.

### DIFF
--- a/sqs/templates/failure_queue_policy.json.tpl
+++ b/sqs/templates/failure_queue_policy.json.tpl
@@ -1,0 +1,23 @@
+{
+  "Version": "2012-10-17",
+  "Id": "file_checks_policy",
+  "Statement": [
+    {
+      "Sid": "statement_for_file_check_queues",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": [
+          "arn:aws:iam::${account_id}:role/TDRDownloadFilesRole",
+          "arn:aws:iam::${account_id}:role/TDRApiUpdateRole",
+          "arn:aws:iam::${account_id}:role/TDRFileFormatRole${title(environment)}",
+          "arn:aws:iam::${account_id}:role/TDRChecksumRole",
+          "arn:aws:iam::${account_id}:role/TDRYaraAvRole"
+        ]
+      },
+      "Action": [
+        "SQS:SendMessage"
+      ],
+      "Resource": "arn:aws:sqs:${region}:${account_id}:${sqs_name}"
+    }
+  ]
+}

--- a/sqs/templates/file_checks_policy.json.tpl
+++ b/sqs/templates/file_checks_policy.json.tpl
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Id": "file_checks_policy",
+  "Statement": [
+    {
+      "Sid": "statement_for_file_check_queues",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${account_id}:role/TDRDownloadFilesRole"
+      },
+      "Action": [
+        "SQS:SendMessage"
+      ],
+      "Resource": "arn:aws:sqs:${region}:${account_id}:${sqs_name}"
+    }
+  ]
+}


### PR DESCRIPTION
From the pen test, we had a low priority finding to say that the access
policies for the queues were too permissive. I've updated the the three
file check queues to only allow the download files role to send messages
to it and I've updated the failure queue to only allow the specific
other queues to call it.
