### PR TITLE
Log stream wildcard variable

### DIFF
--- a/cloudtrail/main.tf
+++ b/cloudtrail/main.tf
@@ -33,7 +33,7 @@ resource "aws_cloudtrail" "cloudtrail" {
   include_global_service_events = var.include_global_service_events
   is_multi_region_trail         = var.is_multi_region_trail
   cloud_watch_logs_role_arn     = aws_iam_role.cloudtrail_role.arn
-  cloud_watch_logs_group_arn    = aws_cloudwatch_log_group.cloudtrail.arn
+  cloud_watch_logs_group_arn    = "${aws_cloudwatch_log_group.cloudtrail.arn}${var.log_stream_wildcard}"
   enable_log_file_validation    = true
   kms_key_id                    = var.kms_key_id
   tags                          = var.common_tags

--- a/cloudtrail/variables.tf
+++ b/cloudtrail/variables.tf
@@ -28,3 +28,8 @@ variable "include_global_service_events" {
 variable "kms_key_id" {
   description = "KMS Key ID for CloudTrail encryption"
 }
+
+variable "log_stream_wildcard" {
+  description = "Later versions of Terraform require the log stream wildcard to be explicitly stated"
+  default     = ""
+}


### PR DESCRIPTION
Later versions of Terraform require the log stream wildcard ':*' to be explicitly stated for the 'cloud_watch_logs_group_arn'

To support upgrade of Terraform allow log stream wildcard to be passed as a variable where the calling module has been upgraded

Default to empty string to continue support of non-upgrade modules