### PR TITLE
Add permissons for the fargate role to assume describe instance role

### DIFF
--- a/iam_policy/templates/jenkins_fargate_integration.json.tpl
+++ b/iam_policy/templates/jenkins_fargate_integration.json.tpl
@@ -37,6 +37,7 @@
         "arn:aws:iam::${account_id}:role/TDRJenkinsRunSsmRoleIntg",
         "arn:aws:iam::${account_id}:role/TDRScriptsTerraformRoleIntg",
         "arn:aws:iam::${account_id}:role/TDRTerraformAssumeRoleIntg",
+        "arn:aws:iam::${account_id}:role/TDRJenkinsRunEC2DescribeInstancesIntg",
         "arn:aws:s3:::tdr-releases-mgmt",
         "arn:aws:s3:::tdr-releases-mgmt/*"
       ]

--- a/iam_policy/templates/jenkins_fargate_prod.json.tpl
+++ b/iam_policy/templates/jenkins_fargate_prod.json.tpl
@@ -46,6 +46,7 @@
         "arn:aws:iam::${account_id}:role/TDRTerraformAssumeRoleProd",
         "arn:aws:iam::${account_id}:role/TDRTerraformAssumeRoleStaging",
         "arn:aws:iam::${account_id}:role/TDRTerraformRoleMgmt",
+        "arn:aws:iam::${account_id}:role/TDRJenkinsRunEC2DescribeInstancesStaging",
         "arn:aws:s3:::tdr-releases-mgmt",
         "arn:aws:s3:::tdr-releases-mgmt/*",
         "arn:aws:s3:::tdr-staging-mgmt",

--- a/iam_policy/templates/jenkins_fargate_prod.json.tpl
+++ b/iam_policy/templates/jenkins_fargate_prod.json.tpl
@@ -47,6 +47,7 @@
         "arn:aws:iam::${account_id}:role/TDRTerraformAssumeRoleStaging",
         "arn:aws:iam::${account_id}:role/TDRTerraformRoleMgmt",
         "arn:aws:iam::${account_id}:role/TDRJenkinsRunEC2DescribeInstancesStaging",
+        "arn:aws:iam::${account_id}:role/TDRJenkinsRunEC2DescribeInstancesProd",
         "arn:aws:s3:::tdr-releases-mgmt",
         "arn:aws:s3:::tdr-releases-mgmt/*",
         "arn:aws:s3:::tdr-staging-mgmt",


### PR DESCRIPTION
There is a role in the sub accounts that is used to describe ec2
instances so we can determine if the bastion needs to be deleted. This
allows Jenkins to pass the role.
