### PR TITLE
Add policy to attach to the api ECS service.

### DIFF
--- a/iam_policy/templates/restored_db_access.json.tpl
+++ b/iam_policy/templates/restored_db_access.json.tpl
@@ -1,0 +1,12 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "rds-db:connect",
+      "Resource": [
+        "${cluster_arn}"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
If we have to create a new database from a snapshot for the API, the task role for the API will need a policy attaching which will allow it to connect to the new cluster. This is called in the tdr-scripts project but the policy definition is here.
