### PR TITLE
Make lambda timeout configurable

### DIFF
--- a/lambda/checksum.tf
+++ b/lambda/checksum.tf
@@ -5,7 +5,7 @@ resource "aws_lambda_function" "checksum_lambda_function" {
   role          = aws_iam_role.checksum_lambda_iam_role.*.arn[0]
   runtime       = "java8"
   filename      = "${path.module}/functions/checksum.jar"
-  timeout       = 180
+  timeout       = var.timeout_seconds
   memory_size   = 1024
   tags          = var.common_tags
   environment {

--- a/lambda/create_db_users.tf
+++ b/lambda/create_db_users.tf
@@ -5,7 +5,7 @@ resource "aws_lambda_function" "create_db_users_lambda_function" {
   role          = aws_iam_role.create_db_users_lambda_iam_role.*.arn[0]
   runtime       = "java11"
   filename      = "${path.module}/functions/create-db-users.jar"
-  timeout       = 180
+  timeout       = var.timeout_seconds
   memory_size   = 1024
   tags          = var.common_tags
   environment {

--- a/lambda/create_keycloak_db_user.tf
+++ b/lambda/create_keycloak_db_user.tf
@@ -5,7 +5,7 @@ resource "aws_lambda_function" "create_keycloak_db_user_lambda_function" {
   role          = aws_iam_role.create_keycloak_db_user_lambda_iam_role.*.arn[0]
   runtime       = "java11"
   filename      = "${path.module}/functions/create-db-users.jar"
-  timeout       = 180
+  timeout       = var.timeout_seconds
   memory_size   = 1024
   tags          = var.common_tags
   environment {

--- a/lambda/download_files.tf
+++ b/lambda/download_files.tf
@@ -5,7 +5,7 @@ resource "aws_lambda_function" "download_files_lambda_function" {
   role          = aws_iam_role.download_files_lambda_iam_role.*.arn[0]
   runtime       = "java11"
   filename      = "${path.module}/functions/download-files.jar"
-  timeout       = 180
+  timeout       = var.timeout_seconds
   memory_size   = 1024
   tags          = var.common_tags
   environment {

--- a/lambda/ecr_scan.tf
+++ b/lambda/ecr_scan.tf
@@ -5,7 +5,7 @@ resource "aws_lambda_function" "ecr_scan_lambda_function" {
   role          = aws_iam_role.ecr_scan_lambda_iam_role.*.arn[0]
   runtime       = "java11"
   filename      = "${path.module}/functions/ecr-scan.jar"
-  timeout       = 180
+  timeout       = var.timeout_seconds
   memory_size   = 512
   tags          = var.common_tags
 

--- a/lambda/notifications.tf
+++ b/lambda/notifications.tf
@@ -5,7 +5,7 @@ resource "aws_lambda_function" "notifications_lambda_function" {
   role          = aws_iam_role.notifications_lambda_iam_role.*.arn[0]
   runtime       = "java11"
   filename      = "${path.module}/functions/notifications.jar"
-  timeout       = 180
+  timeout       = var.timeout_seconds
   memory_size   = 1024
   tags          = var.common_tags
   environment {

--- a/lambda/variables.tf
+++ b/lambda/variables.tf
@@ -11,6 +11,12 @@ variable "apply_resource" {
   default     = true
 }
 
+variable "timeout_seconds" {
+  description = "The maximum time the function is allowed to run"
+  type        = number
+  default     = 180
+}
+
 variable "lambda_yara_av" {
   description = "deploy Lambda function to run yara av checks on files"
   default     = false

--- a/lambda/yara_av.tf
+++ b/lambda/yara_av.tf
@@ -5,7 +5,7 @@ resource "aws_lambda_function" "lambda_function" {
   role          = aws_iam_role.lambda_iam_role.*.arn[0]
   runtime       = "python3.7"
   filename      = "${path.module}/functions/yara-av.zip"
-  timeout       = 180
+  timeout       = var.timeout_seconds
   memory_size   = 3008
   tags          = var.common_tags
   environment {


### PR DESCRIPTION
This will allow tdr-terraform-environments to set the value, and use it to determine other values like the corresponding SQS message visibility timeout.

Set the default to 180 seconds, because this is a common value that many of the non-file-check Lambdas use.

For now, keep the hard-coded values for Lambdas which do not use the default values. Once tdr-terraform-frontend has been updated to pass in this parameter, there will be another PR to use the parameter for all Lambdas.