### PR TITLE
Update all lambdas to use timeout parameter

### DIFF
--- a/lambda/api_update.tf
+++ b/lambda/api_update.tf
@@ -5,7 +5,7 @@ resource "aws_lambda_function" "lambda_api_update_function" {
   role          = aws_iam_role.lambda_api_update_iam_role.*.arn[0]
   runtime       = "java8"
   filename      = "${path.module}/functions/api-update.jar"
-  timeout       = 20
+  timeout       = var.timeout_seconds
   memory_size   = 512
   tags          = var.common_tags
   environment {

--- a/lambda/export_api_authoriser.tf
+++ b/lambda/export_api_authoriser.tf
@@ -5,7 +5,7 @@ resource "aws_lambda_function" "export_api_authoriser_lambda_function" {
   role          = aws_iam_role.export_api_authoriser_lambda_iam_role.*.arn[0]
   runtime       = "java11"
   filename      = "${path.module}/functions/export-authoriser.jar"
-  timeout       = 10
+  timeout       = var.timeout_seconds
   memory_size   = 4096
   tags          = var.common_tags
   environment {

--- a/lambda/file_format.tf
+++ b/lambda/file_format.tf
@@ -5,7 +5,7 @@ resource "aws_lambda_function" "file_format_lambda_function" {
   role          = aws_iam_role.file_format_lambda_iam_role.*.arn[0]
   runtime       = "java11"
   filename      = "${path.module}/functions/file-format.jar"
-  timeout       = 900
+  timeout       = var.timeout_seconds
   memory_size   = 1024
   tags          = var.common_tags
   environment {

--- a/lambda/log_data.tf
+++ b/lambda/log_data.tf
@@ -43,7 +43,7 @@ resource "aws_lambda_function" "log_data_lambda" {
   handler          = "lambda_function.lambda_handler"
   source_code_hash = data.archive_file.log_data_lambda.output_base64sha256
   runtime          = "python3.7"
-  timeout          = 30
+  timeout          = var.timeout_seconds
   publish          = true
 
   tags = merge(


### PR DESCRIPTION
All of the Terraform repos have been updated to pass this parameter if the value is not the default, so replace all the hard-coded values with the parameter.

Marking as draft until https://github.com/nationalarchives/tdr-aws-accounts/pull/33 is merged.