### PR TITLE
Add reserved concurrency variable and set for download files lambda

### DIFF
--- a/lambda/api_update.tf
+++ b/lambda/api_update.tf
@@ -1,13 +1,14 @@
 resource "aws_lambda_function" "lambda_api_update_function" {
-  count         = local.count_api_update
-  function_name = local.api_update_function_name
-  handler       = "uk.gov.nationalarchives.api.update.Lambda::update"
-  role          = aws_iam_role.lambda_api_update_iam_role.*.arn[0]
-  runtime       = "java8"
-  filename      = "${path.module}/functions/api-update.jar"
-  timeout       = var.timeout_seconds
-  memory_size   = 512
-  tags          = var.common_tags
+  count                          = local.count_api_update
+  function_name                  = local.api_update_function_name
+  handler                        = "uk.gov.nationalarchives.api.update.Lambda::update"
+  role                           = aws_iam_role.lambda_api_update_iam_role.*.arn[0]
+  runtime                        = "java8"
+  filename                       = "${path.module}/functions/api-update.jar"
+  timeout                        = var.timeout_seconds
+  memory_size                    = 512
+  reserved_concurrent_executions = var.reserved_concurrency
+  tags                           = var.common_tags
   environment {
     variables = {
       API_URL       = aws_kms_ciphertext.environment_vars_api_update["api_url"].ciphertext_blob

--- a/lambda/checksum.tf
+++ b/lambda/checksum.tf
@@ -1,13 +1,14 @@
 resource "aws_lambda_function" "checksum_lambda_function" {
-  count         = local.count_checksum
-  function_name = local.checksum_function_name
-  handler       = "uk.gov.nationalarchives.checksum.Lambda::process"
-  role          = aws_iam_role.checksum_lambda_iam_role.*.arn[0]
-  runtime       = "java8"
-  filename      = "${path.module}/functions/checksum.jar"
-  timeout       = var.timeout_seconds
-  memory_size   = 1024
-  tags          = var.common_tags
+  count                          = local.count_checksum
+  function_name                  = local.checksum_function_name
+  handler                        = "uk.gov.nationalarchives.checksum.Lambda::process"
+  role                           = aws_iam_role.checksum_lambda_iam_role.*.arn[0]
+  runtime                        = "java8"
+  filename                       = "${path.module}/functions/checksum.jar"
+  timeout                        = var.timeout_seconds
+  memory_size                    = 1024
+  reserved_concurrent_executions = var.reserved_concurrency
+  tags                           = var.common_tags
   environment {
     variables = {
       INPUT_QUEUE      = aws_kms_ciphertext.environment_vars_checksum["input_queue"].ciphertext_blob

--- a/lambda/create_db_users.tf
+++ b/lambda/create_db_users.tf
@@ -1,13 +1,14 @@
 resource "aws_lambda_function" "create_db_users_lambda_function" {
-  count         = local.count_create_db_users
-  function_name = local.create_db_users_function_name
-  handler       = "uk.gov.nationalarchives.db.users.Lambda::process"
-  role          = aws_iam_role.create_db_users_lambda_iam_role.*.arn[0]
-  runtime       = "java11"
-  filename      = "${path.module}/functions/create-db-users.jar"
-  timeout       = var.timeout_seconds
-  memory_size   = 1024
-  tags          = var.common_tags
+  count                          = local.count_create_db_users
+  function_name                  = local.create_db_users_function_name
+  handler                        = "uk.gov.nationalarchives.db.users.Lambda::process"
+  role                           = aws_iam_role.create_db_users_lambda_iam_role.*.arn[0]
+  runtime                        = "java11"
+  filename                       = "${path.module}/functions/create-db-users.jar"
+  timeout                        = var.timeout_seconds
+  memory_size                    = 1024
+  reserved_concurrent_executions = var.reserved_concurrency
+  tags                           = var.common_tags
   environment {
     variables = {
       DB_ADMIN_USER     = aws_kms_ciphertext.environment_vars_create_db_users["db_admin_user"].ciphertext_blob

--- a/lambda/create_keycloak_db_user.tf
+++ b/lambda/create_keycloak_db_user.tf
@@ -1,13 +1,14 @@
 resource "aws_lambda_function" "create_keycloak_db_user_lambda_function" {
-  count         = local.count_create_keycloak_db_user
-  function_name = local.create_keycloak_db_user_function_name
-  handler       = "uk.gov.nationalarchives.db.users.Lambda::process"
-  role          = aws_iam_role.create_keycloak_db_user_lambda_iam_role.*.arn[0]
-  runtime       = "java11"
-  filename      = "${path.module}/functions/create-db-users.jar"
-  timeout       = var.timeout_seconds
-  memory_size   = 1024
-  tags          = var.common_tags
+  count                          = local.count_create_keycloak_db_user
+  function_name                  = local.create_keycloak_db_user_function_name
+  handler                        = "uk.gov.nationalarchives.db.users.Lambda::process"
+  role                           = aws_iam_role.create_keycloak_db_user_lambda_iam_role.*.arn[0]
+  runtime                        = "java11"
+  filename                       = "${path.module}/functions/create-db-users.jar"
+  timeout                        = var.timeout_seconds
+  memory_size                    = 1024
+  reserved_concurrent_executions = var.reserved_concurrency
+  tags                           = var.common_tags
   environment {
     variables = {
       DB_ADMIN_USER     = aws_kms_ciphertext.environment_vars_create_keycloak_db_user["db_admin_user"].ciphertext_blob

--- a/lambda/download_files.tf
+++ b/lambda/download_files.tf
@@ -1,13 +1,14 @@
 resource "aws_lambda_function" "download_files_lambda_function" {
-  count         = local.count_download_files
-  function_name = local.download_files_function_name
-  handler       = "uk.gov.nationalarchives.downloadfiles.Lambda::process"
-  role          = aws_iam_role.download_files_lambda_iam_role.*.arn[0]
-  runtime       = "java11"
-  filename      = "${path.module}/functions/download-files.jar"
-  timeout       = var.timeout_seconds
-  memory_size   = 1024
-  tags          = var.common_tags
+  count                          = local.count_download_files
+  function_name                  = local.download_files_function_name
+  handler                        = "uk.gov.nationalarchives.downloadfiles.Lambda::process"
+  role                           = aws_iam_role.download_files_lambda_iam_role.*.arn[0]
+  runtime                        = "java11"
+  filename                       = "${path.module}/functions/download-files.jar"
+  timeout                        = var.timeout_seconds
+  memory_size                    = 1024
+  reserved_concurrent_executions = var.reserved_concurrency
+  tags                           = var.common_tags
   environment {
     variables = {
       ENVIRONMENT       = aws_kms_ciphertext.environment_vars_download_files["environment"].ciphertext_blob

--- a/lambda/ecr_scan.tf
+++ b/lambda/ecr_scan.tf
@@ -1,13 +1,14 @@
 resource "aws_lambda_function" "ecr_scan_lambda_function" {
-  count         = local.count_ecr_scan
-  function_name = "${var.project}-ecr-scan-${local.environment}"
-  handler       = "uk.gov.nationalarchives.ecr.scan.Lambda::process"
-  role          = aws_iam_role.ecr_scan_lambda_iam_role.*.arn[0]
-  runtime       = "java11"
-  filename      = "${path.module}/functions/ecr-scan.jar"
-  timeout       = var.timeout_seconds
-  memory_size   = 512
-  tags          = var.common_tags
+  count                          = local.count_ecr_scan
+  function_name                  = "${var.project}-ecr-scan-${local.environment}"
+  handler                        = "uk.gov.nationalarchives.ecr.scan.Lambda::process"
+  role                           = aws_iam_role.ecr_scan_lambda_iam_role.*.arn[0]
+  runtime                        = "java11"
+  filename                       = "${path.module}/functions/ecr-scan.jar"
+  timeout                        = var.timeout_seconds
+  memory_size                    = 512
+  reserved_concurrent_executions = var.reserved_concurrency
+  tags                           = var.common_tags
 
   lifecycle {
     ignore_changes = [filename]

--- a/lambda/export_api_authoriser.tf
+++ b/lambda/export_api_authoriser.tf
@@ -1,13 +1,14 @@
 resource "aws_lambda_function" "export_api_authoriser_lambda_function" {
-  count         = local.count_export_api_authoriser
-  function_name = local.export_api_authoriser_function_name
-  handler       = "uk.gov.nationalarchives.consignmentexport.authoriser.Lambda::process"
-  role          = aws_iam_role.export_api_authoriser_lambda_iam_role.*.arn[0]
-  runtime       = "java11"
-  filename      = "${path.module}/functions/export-authoriser.jar"
-  timeout       = var.timeout_seconds
-  memory_size   = 4096
-  tags          = var.common_tags
+  count                          = local.count_export_api_authoriser
+  function_name                  = local.export_api_authoriser_function_name
+  handler                        = "uk.gov.nationalarchives.consignmentexport.authoriser.Lambda::process"
+  role                           = aws_iam_role.export_api_authoriser_lambda_iam_role.*.arn[0]
+  runtime                        = "java11"
+  filename                       = "${path.module}/functions/export-authoriser.jar"
+  timeout                        = var.timeout_seconds
+  memory_size                    = 4096
+  reserved_concurrent_executions = var.reserved_concurrency
+  tags                           = var.common_tags
   environment {
     variables = {
       API_URL = aws_kms_ciphertext.environment_vars_export_api_authoriser["api_url"].ciphertext_blob

--- a/lambda/file_format.tf
+++ b/lambda/file_format.tf
@@ -1,13 +1,14 @@
 resource "aws_lambda_function" "file_format_lambda_function" {
-  count         = local.count_file_format
-  function_name = local.file_format_function_name
-  handler       = "uk.gov.nationalarchives.fileformat.Lambda::process"
-  role          = aws_iam_role.file_format_lambda_iam_role.*.arn[0]
-  runtime       = "java11"
-  filename      = "${path.module}/functions/file-format.jar"
-  timeout       = var.timeout_seconds
-  memory_size   = 1024
-  tags          = var.common_tags
+  count                          = local.count_file_format
+  function_name                  = local.file_format_function_name
+  handler                        = "uk.gov.nationalarchives.fileformat.Lambda::process"
+  role                           = aws_iam_role.file_format_lambda_iam_role.*.arn[0]
+  runtime                        = "java11"
+  filename                       = "${path.module}/functions/file-format.jar"
+  timeout                        = var.timeout_seconds
+  memory_size                    = 1024
+  reserved_concurrent_executions = var.reserved_concurrency
+  tags                           = var.common_tags
   environment {
     variables = {
       ENVIRONMENT    = aws_kms_ciphertext.environment_vars_file_format["environment"].ciphertext_blob

--- a/lambda/log_data.tf
+++ b/lambda/log_data.tf
@@ -35,16 +35,17 @@ data "archive_file" "log_data_lambda" {
 }
 
 resource "aws_lambda_function" "log_data_lambda" {
-  count            = local.count_log_data
-  filename         = data.archive_file.log_data_lambda.output_path
-  function_name    = local.log_data_function_name
-  description      = "Aggregate log data to a target S3 bucket"
-  role             = aws_iam_role.log_data_assume_role.*.arn[0]
-  handler          = "lambda_function.lambda_handler"
-  source_code_hash = data.archive_file.log_data_lambda.output_base64sha256
-  runtime          = "python3.7"
-  timeout          = var.timeout_seconds
-  publish          = true
+  count                          = local.count_log_data
+  filename                       = data.archive_file.log_data_lambda.output_path
+  function_name                  = local.log_data_function_name
+  description                    = "Aggregate log data to a target S3 bucket"
+  role                           = aws_iam_role.log_data_assume_role.*.arn[0]
+  handler                        = "lambda_function.lambda_handler"
+  source_code_hash               = data.archive_file.log_data_lambda.output_base64sha256
+  runtime                        = "python3.7"
+  timeout                        = var.timeout_seconds
+  publish                        = true
+  reserved_concurrent_executions = var.reserved_concurrency
 
   tags = merge(
     var.common_tags,

--- a/lambda/notifications.tf
+++ b/lambda/notifications.tf
@@ -1,13 +1,14 @@
 resource "aws_lambda_function" "notifications_lambda_function" {
-  count         = local.count_notifications
-  function_name = local.notifications_function_name
-  handler       = "uk.gov.nationalarchives.notifications.Lambda::process"
-  role          = aws_iam_role.notifications_lambda_iam_role.*.arn[0]
-  runtime       = "java11"
-  filename      = "${path.module}/functions/notifications.jar"
-  timeout       = var.timeout_seconds
-  memory_size   = 1024
-  tags          = var.common_tags
+  count                          = local.count_notifications
+  function_name                  = local.notifications_function_name
+  handler                        = "uk.gov.nationalarchives.notifications.Lambda::process"
+  role                           = aws_iam_role.notifications_lambda_iam_role.*.arn[0]
+  runtime                        = "java11"
+  filename                       = "${path.module}/functions/notifications.jar"
+  timeout                        = var.timeout_seconds
+  memory_size                    = 1024
+  reserved_concurrent_executions = var.reserved_concurrency
+  tags                           = var.common_tags
   environment {
     variables = {
       SLACK_WEBHOOK         = aws_kms_ciphertext.environment_vars_notifications["slack_webhook"].ciphertext_blob

--- a/lambda/service_unavailable.tf
+++ b/lambda/service_unavailable.tf
@@ -1,13 +1,14 @@
 resource "aws_lambda_function" "lambda_service_unavailable_function" {
-  count         = local.count_service_unavailable
-  function_name = local.service_unavailable_function_name
-  handler       = "app.lambda_handler"
-  role          = aws_iam_role.lambda_service_unavailable_iam_role.*.arn[0]
-  runtime       = "python3.8"
-  filename      = "${path.module}/functions/service-unavailable.zip"
-  timeout       = 3
-  memory_size   = 128
-  tags          = var.common_tags
+  count                          = local.count_service_unavailable
+  function_name                  = local.service_unavailable_function_name
+  handler                        = "app.lambda_handler"
+  role                           = aws_iam_role.lambda_service_unavailable_iam_role.*.arn[0]
+  runtime                        = "python3.8"
+  filename                       = "${path.module}/functions/service-unavailable.zip"
+  timeout                        = 3
+  memory_size                    = 128
+  reserved_concurrent_executions = var.reserved_concurrency
+  tags                           = var.common_tags
 
   vpc_config {
     subnet_ids         = var.private_subnet_ids

--- a/lambda/variables.tf
+++ b/lambda/variables.tf
@@ -214,3 +214,8 @@ variable "database_name" {
   description = "The name to pass to the create db users lambda. Values are either consignmentapi to create the API users or bastion to create the bastion user"
   default     = ""
 }
+
+variable "reserved_concurrency" {
+  description = "The total number of concurrent lambdas which can run at one time. Defaults to -1 which is unlimited up to the account limit"
+  default     = -1
+}

--- a/lambda/yara_av.tf
+++ b/lambda/yara_av.tf
@@ -1,13 +1,14 @@
 resource "aws_lambda_function" "lambda_function" {
-  count         = local.count_av_yara
-  function_name = local.yara_av_function_name
-  handler       = "matcher.matcher_lambda_handler"
-  role          = aws_iam_role.lambda_iam_role.*.arn[0]
-  runtime       = "python3.7"
-  filename      = "${path.module}/functions/yara-av.zip"
-  timeout       = var.timeout_seconds
-  memory_size   = 3008
-  tags          = var.common_tags
+  count                          = local.count_av_yara
+  function_name                  = local.yara_av_function_name
+  handler                        = "matcher.matcher_lambda_handler"
+  role                           = aws_iam_role.lambda_iam_role.*.arn[0]
+  runtime                        = "python3.7"
+  filename                       = "${path.module}/functions/yara-av.zip"
+  timeout                        = var.timeout_seconds
+  memory_size                    = 3008
+  reserved_concurrent_executions = var.reserved_concurrency
+  tags                           = var.common_tags
   environment {
     variables = {
       ENVIRONMENT    = aws_kms_ciphertext.environment_vars_yara_av["environment"].ciphertext_blob


### PR DESCRIPTION
As part of the work we're doing to try and reduce load on the API to
allow for larger transfers, we want to restrict the number of concurrent
download files lambdas we have which restricts the number of concurrent
file check lambdas running which reduces the load on the API.

I've added in the variable and added the new parameter to the download
files lambda.
