### PR TITLE
Add SendTaskHeartbeat permission.

### DIFF
--- a/ecs/templates/consignment_export_task_policy.json.tpl
+++ b/ecs/templates/consignment_export_task_policy.json.tpl
@@ -5,7 +5,8 @@
       "Effect": "Allow",
       "Action": [
         "states:SendTaskSuccess",
-        "states:SendTaskFailure"
+        "states:SendTaskFailure",
+        "states:SendTaskHeartbeat"
       ],
       "Resource": [
         "arn:aws:states:${aws_region}:${account}:stateMachine:TDRConsignmentExport${titleEnvironment}"


### PR DESCRIPTION
We're trying to send the task heartbeat to the step function to prevent
exports getting stuck but the task role was missing the permission to
allow it to do this.
