### PR TITLE
Remove old iam roles from auth ecr policy.

### DIFF
--- a/ecr/templates/auth_server_policy.json.tpl
+++ b/ecr/templates/auth_server_policy.json.tpl
@@ -6,9 +6,6 @@
       "Effect": "Allow",
       "Principal": {
         "AWS": [
-          "arn:aws:iam::${intg_account}:role/keycloak_ecs_execution_role_intg",
-          "arn:aws:iam::${staging_account}:role/keycloak_ecs_execution_role_staging",
-          "arn:aws:iam::${prod_account}:role/keycloak_ecs_execution_role_prod",
           "arn:aws:iam::${intg_account}:role/KeycloakECSExecutionRoleIntg",
           "arn:aws:iam::${staging_account}:role/KeycloakECSExecutionRoleStaging",
           "arn:aws:iam::${prod_account}:role/KeycloakECSExecutionRoleProd"


### PR DESCRIPTION
As part of moving Keycloak to the TDR VPC, I renamed the roles to match
the pascal case naming of the newer ones. This has all been moved over
so these roles no longer exist.
