### PR TITLE
Allow custom ACL grants for S3 buckets.

### DIFF
--- a/s3/main.tf
+++ b/s3/main.tf
@@ -55,7 +55,7 @@ resource "aws_s3_bucket_notification" "log_bucket_notification" {
 resource "aws_s3_bucket" "bucket" {
   count         = var.apply_resource == true ? 1 : 0
   bucket        = local.bucket_name
-  acl           = var.acl
+  acl           = length(var.full_access_ids) == 0 ? var.acl : null
   force_destroy = var.force_destroy
 
   server_side_encryption_configuration {
@@ -63,6 +63,15 @@ resource "aws_s3_bucket" "bucket" {
       apply_server_side_encryption_by_default {
         sse_algorithm = "AES256"
       }
+    }
+  }
+
+  dynamic "grant" {
+    for_each = var.full_access_ids
+    content {
+      permissions = ["FULL_CONTROL"]
+      type        = "CanonicalUser"
+      id          = grant.value
     }
   }
 

--- a/s3/main.tf
+++ b/s3/main.tf
@@ -55,7 +55,7 @@ resource "aws_s3_bucket_notification" "log_bucket_notification" {
 resource "aws_s3_bucket" "bucket" {
   count         = var.apply_resource == true ? 1 : 0
   bucket        = local.bucket_name
-  acl           = length(var.full_access_ids) == 0 ? var.acl : null
+  acl           = length(var.canonical_user_grants) == 0 ? var.acl : null
   force_destroy = var.force_destroy
 
   server_side_encryption_configuration {
@@ -67,11 +67,11 @@ resource "aws_s3_bucket" "bucket" {
   }
 
   dynamic "grant" {
-    for_each = var.full_access_ids
+    for_each = var.canonical_user_grants
     content {
-      permissions = ["FULL_CONTROL"]
+      permissions = grant.value.permissions
       type        = "CanonicalUser"
-      id          = grant.value
+      id          = grant.value.id
     }
   }
 

--- a/s3/variables.tf
+++ b/s3/variables.tf
@@ -24,6 +24,12 @@ variable "acl" {
   default = "private"
 }
 
+variable "full_control_canonical_ids" {
+  description = "A list of canonical user IDs to allow full access for. If this is set, you cannot use a canned ACL"
+  type        = list(string)
+  default     = []
+}
+
 variable "versioning" {
   default = true
 }

--- a/s3/variables.tf
+++ b/s3/variables.tf
@@ -24,9 +24,9 @@ variable "acl" {
   default = "private"
 }
 
-variable "full_control_canonical_ids" {
-  description = "A list of canonical user IDs to allow full access for. If this is set, you cannot use a canned ACL"
-  type        = list(string)
+variable "canonical_user_grants" {
+  description = "A list of canonical user IDs and their permissions. If this is set, you cannot use a canned ACL"
+  type        = list(object({ id = string, permissions = list(string) }))
   default     = []
 }
 


### PR DESCRIPTION
The S3 buckets can only have canned ACLs at the moment https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl
We need to allow full control for the logs delivery account described https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html#AccessLogsBucketAndFileOwnership
This allows Cloudfront to log requests made to S3.
There is a separate change in terraform-environments to set the new variable
