### PR TITLE
Add policy for AV update checks.

### DIFF
--- a/iam_policy/templates/jenkins_av_lambda.json.tpl
+++ b/iam_policy/templates/jenkins_av_lambda.json.tpl
@@ -6,8 +6,8 @@
       "Effect": "Allow",
       "Action": "s3:GetObject",
       "Resource": [
-        "arn:aws:s3:::tdr-backend-code-mgmt/*",
-        "arn:aws:s3:::tdr-antivirus-test-files-mgmt/*"
+        "arn:aws:s3:::tdr-antivirus-test-files-mgmt/*",
+        "arn:aws:s3:::tdr-backend-code-mgmt/*"
       ]
     }
   ]

--- a/iam_policy/templates/jenkins_av_lambda.json.tpl
+++ b/iam_policy/templates/jenkins_av_lambda.json.tpl
@@ -1,0 +1,14 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": "s3:GetObject",
+      "Resource": [
+        "arn:aws:s3:::tdr-backend-code-mgmt/*",
+        "arn:aws:s3:::tdr-antivirus-test-files-mgmt/*"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The rule update job needs access to backend-code-mgmt to get the
existing rules file in order to compare them and the
antivirus-test-files for the test files.
