### PR TITLE
Add missing ListBucket permission.

### DIFF
--- a/iam_policy/templates/jenkins_av_lambda.json.tpl
+++ b/iam_policy/templates/jenkins_av_lambda.json.tpl
@@ -4,8 +4,9 @@
     {
       "Sid": "",
       "Effect": "Allow",
-      "Action": "s3:GetObject",
+      "Action": ["s3:GetObject","s3:ListBucket"],
       "Resource": [
+        "arn:aws:s3:::tdr-antivirus-test-files-mgmt",
         "arn:aws:s3:::tdr-antivirus-test-files-mgmt/*",
         "arn:aws:s3:::tdr-backend-code-mgmt/*"
       ]


### PR DESCRIPTION
We need the ListBucket permission so the Jenkins job can download the
test files.
