### PR TITLE
Remove usage of original dirty bucket

### DIFF
--- a/lambda/templates/av_lambda.json.tpl
+++ b/lambda/templates/av_lambda.json.tpl
@@ -20,9 +20,7 @@
       ],
       "Resource" : [
         "arn:aws:s3:::tdr-upload-files-cloudfront-dirty-${environment}",
-        "arn:aws:s3:::tdr-upload-files-cloudfront-dirty-${environment}/*",
-        "arn:aws:s3:::tdr-upload-files-dirty-${environment}/*",
-        "arn:aws:s3:::tdr-upload-files-dirty-${environment}"
+        "arn:aws:s3:::tdr-upload-files-cloudfront-dirty-${environment}/*"
       ]
     },
     {

--- a/lambda/templates/download_files_lambda.json.tpl
+++ b/lambda/templates/download_files_lambda.json.tpl
@@ -20,9 +20,7 @@
       ],
       "Resource" : [
         "arn:aws:s3:::tdr-upload-files-cloudfront-dirty-${environment}",
-        "arn:aws:s3:::tdr-upload-files-cloudfront-dirty-${environment}/*",
-        "arn:aws:s3:::tdr-upload-files-dirty-${environment}/*",
-        "arn:aws:s3:::tdr-upload-files-dirty-${environment}"
+        "arn:aws:s3:::tdr-upload-files-cloudfront-dirty-${environment}/*"
       ]
     },
     {


### PR DESCRIPTION
This is a continuation of this [PR](https://github.com/nationalarchives/tdr-terraform-environments/pull/181) There are probably more usages of the original bucket within here