### PR TITLE
Add US to the allowed countries for intg and staging

### DIFF
--- a/waf/main.tf
+++ b/waf/main.tf
@@ -59,7 +59,7 @@ resource "aws_wafv2_rule_group" "rule_group" {
     }
     statement {
       geo_match_statement {
-        country_codes = ["GB"]
+        country_codes = var.environment == "intg" || var.environment == "staging" ? ["GB", "US"] : ["GB"]
       }
     }
     visibility_config {


### PR DESCRIPTION
This allows the GitHub actions runners to access the front end so it can
run the e2e tests.
