### PR TITLE
Make team slug optional.

### DIFF
--- a/github_environments/main.tf
+++ b/github_environments/main.tf
@@ -3,16 +3,17 @@ data "github_repository" "repository" {
 }
 
 data "github_team" "team" {
-  slug = var.team_slug
+  count = var.team_slug == "" ? 0 : 1
+  slug  = var.team_slug
 }
 
 resource "github_repository_environment" "environment" {
   environment = var.environment
   repository  = data.github_repository.repository.name
   dynamic "reviewers" {
-    for_each = var.environment == "intg" ? [] : [var.team_slug]
+    for_each = var.environment == "intg" || var.team_slug == "" ? [] : [var.team_slug]
     content {
-      teams = [data.github_team.team.id]
+      teams = [data.github_team.team[0].id]
     }
   }
 }

--- a/github_environments/variables.tf
+++ b/github_environments/variables.tf
@@ -2,7 +2,9 @@ variable "repository_name" {}
 
 variable "environment" {}
 
-variable "team_slug" {}
+variable "team_slug" {
+  default = ""
+}
 
 variable "secrets" {
   default = {}


### PR DESCRIPTION
At the moment, we have to approve each one of the parallel jobs because
of the protection rules on the staging and prod environments. This
doesn't make sense for the e2e tests so I've added in an option to not
set a team slug which won't add protection rules.
