### PR TITLE
Upgrade databases

### DIFF
--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -9,7 +9,7 @@ variable "engine" {
   default = "aurora-postgresql"
 }
 variable "engine_version" {
-  default = "11.9"
+  default = "11.13"
 }
 variable "environment" {}
 variable "instance_class" {


### PR DESCRIPTION
AWS has been upgrading the RDS databases in the background and now the
versions are out of sync with terraform.

This now matches the deployed version.
