### PR TITLE
Add PutObjectTagging.

### DIFF
--- a/s3/templates/cloudfront_oai.json.tpl
+++ b/s3/templates/cloudfront_oai.json.tpl
@@ -7,7 +7,10 @@
       "Principal": {
         "AWS": "${cloudfront_oai}"
       },
-      "Action": "s3:PutObject",
+      "Action": [
+        "s3:PutObject",
+        "s3:PutObjectTagging"
+      ],
       "Resource": "arn:aws:s3:::${bucket_name}/*"
     },
     {


### PR DESCRIPTION
This allows the Cloudfront OAI to tag the objects.
