### PR TITLE
Add ObjectTagging permissions.

### DIFF
--- a/lambda/templates/av_lambda.json.tpl
+++ b/lambda/templates/av_lambda.json.tpl
@@ -16,6 +16,7 @@
       "Effect": "Allow",
       "Action": [
         "s3:GetObject",
+        "s3:GetObjectTagging",
         "s3:ListBucket"
       ],
       "Resource" : [
@@ -26,7 +27,8 @@
     {
       "Effect": "Allow",
       "Action": [
-        "s3:PutObject"
+        "s3:PutObject",
+        "s3:PutObjectTagging"
       ],
       "Resource" : [
         "arn:aws:s3:::tdr-upload-files-quarantine-${environment}/*",


### PR DESCRIPTION
The AV lambda needs to copy files from the dirty to the clean bucket.

These files are now tagged so the AV lambda needs these permissions to
get the tags from the dirty bucket and put them back on the clean
bucket.
