### PR TITLE
Incorrect name used for the 'sandbox' environment

### DIFF
--- a/lambda/data.tf
+++ b/lambda/data.tf
@@ -21,7 +21,7 @@ data "aws_ssm_parameter" "prod_account_number" {
 }
 
 data "aws_ssm_parameter" "cloudfront_private_key_pem" {
-  count = var.project == "tdr" && local.environment != "mgmt" && local.environment != "sandbox" ? 1 : 0
+  count = var.project == "tdr" && local.environment != "mgmt" && local.environment != "sbox" ? 1 : 0
   name  = "/${local.environment}/cloudfront/key/private/pem"
 }
 


### PR DESCRIPTION
Value should be 'sbox'

This is causing the tdr-aws-account terraform to fail when run against the AWS sandbox environment