### PR TITLE
TDR 1829 changes for advanced shield

### DIFF
--- a/cloudfront/outputs.tf
+++ b/cloudfront/outputs.tf
@@ -13,3 +13,7 @@ output "cloudfront_hosted_zone_id" {
 output "cloudfront_key_pair_id" {
   value = aws_cloudfront_public_key.cookie_signing_key.id
 }
+
+output "cloudfront_arn" {
+  value = aws_cloudfront_distribution.cloudfront_distribution.arn
+}

--- a/kms/templates/message_system_access.json.tpl
+++ b/kms/templates/message_system_access.json.tpl
@@ -21,7 +21,7 @@
         "kms:Decrypt",
         "kms:GenerateDataKey*"
       ],
-     "Resource": "*"
+      "Resource": "*"
     },
     {
       "Effect": "Allow",
@@ -38,7 +38,6 @@
           "kms:EncryptionContext:aws:sqs:arn": [
             "arn:aws:sqs:eu-west-2:${account_id}:tdr-backend-check-failure-${environment}",
             "arn:aws:sqs:eu-west-2:${account_id}:tdr-download-files-${environment}"
-
           ]
         }
       }
@@ -60,6 +59,17 @@
           ]
         }
       }
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "cloudwatch.amazonaws.com"
+      },
+      "Action": [
+        "kms:Decrypt",
+        "kms:GenerateDataKey*"
+      ],
+      "Resource": "*"
     }
   ]
 }

--- a/shield/main.tf
+++ b/shield/main.tf
@@ -1,0 +1,5 @@
+resource "aws_shield_protection" "shield_protection" {
+  for_each     = var.resource_arns
+  name         = "${upper(var.project)}ShieldProtection"
+  resource_arn = each.value
+}

--- a/shield/variables.tf
+++ b/shield/variables.tf
@@ -1,0 +1,4 @@
+variable "resource_arns" {
+  type = set(string)
+}
+variable "project" {}

--- a/waf/main.tf
+++ b/waf/main.tf
@@ -90,7 +90,7 @@ resource "aws_wafv2_web_acl" "acl" {
     }
     statement {
       rate_based_statement {
-        limit = 100
+        limit = 5000
       }
     }
     visibility_config {

--- a/waf/main.tf
+++ b/waf/main.tf
@@ -81,7 +81,24 @@ resource "aws_wafv2_web_acl" "acl" {
   default_action {
     block {}
   }
+  rule {
 
+    name     = "rate-based-rule"
+    priority = 0
+    action {
+      block {}
+    }
+    statement {
+      rate_based_statement {
+        limit = 100
+      }
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "acl-rule-metric"
+      sampled_requests_enabled   = false
+    }
+  }
   rule {
     name     = "acl-rule"
     priority = 1


### PR DESCRIPTION
- Add cloudfront arn to outputs.
- Add cloudwatch to the KMS policy to allow cloudwatch rules to be sent to the notifications topic.
- Add a rate-based-rule.
- Add shield protection module
