### PR TITLE
Add outside collaborators parameter.

### DIFF
--- a/github_repositories/main.tf
+++ b/github_repositories/main.tf
@@ -8,3 +8,9 @@ resource "github_actions_secret" "repository_secret" {
   secret_name     = each.key
   plaintext_value = each.value
 }
+
+resource "github_repository_collaborator" "collaborators" {
+  for_each   = var.collaborators
+  repository = data.github_repository.repository.name
+  username   = each.value
+}

--- a/github_repositories/variables.tf
+++ b/github_repositories/variables.tf
@@ -3,3 +3,9 @@ variable "repository_name" {}
 variable "secrets" {
   default = {}
 }
+
+variable "collaborators" {
+  description = "Outside collaborators to add to the repository"
+  default     = []
+  type        = set(string)
+}


### PR DESCRIPTION
This will be used to add outside collaborators to the tdr-reporting
repo. It will read the collaborators field from this PR https://github.com/nationalarchives/tdr-configurations/pull/125
