### PR TITLE
Add DE to allowed regions

### DIFF
--- a/waf/main.tf
+++ b/waf/main.tf
@@ -59,7 +59,7 @@ resource "aws_wafv2_rule_group" "rule_group" {
     }
     statement {
       geo_match_statement {
-        country_codes = var.environment == "intg" || var.environment == "staging" ? ["GB", "US"] : ["GB"]
+        country_codes = var.environment == "intg" || var.environment == "staging" ? ["GB", "US", "DE"] : ["GB"]
       }
     }
     visibility_config {


### PR DESCRIPTION
The problem is that some of the GitHub action IPs look like they're coming from Germany which is not on our allowed list of countries so it's returning 403. I've added Germany in to the allowed list and the tests are passing
