### PR TITLE
Increase timeout for export

### DIFF
--- a/stepfunctions/templates/consignment_export_definition.json.tpl
+++ b/stepfunctions/templates/consignment_export_definition.json.tpl
@@ -6,7 +6,7 @@
       "Type": "Task",
       "Resource": "arn:aws:states:::ecs:runTask.waitForTaskToken",
       "HeartbeatSeconds": 60,
-      "TimeoutSeconds": 600,
+      "TimeoutSeconds": 1800,
       "Retry": [
         {
           "ErrorEquals": [


### PR DESCRIPTION
The timeout was set to 10 minutes and the 10largefiles export (Around
5.5Gb) was taking around 15 minutes.

This should allow us a roughly 10Gb total export before we have to change it
again.
