### PR TITLE
Increase WAF rate limits.

### DIFF
--- a/waf/main.tf
+++ b/waf/main.tf
@@ -90,7 +90,16 @@ resource "aws_wafv2_web_acl" "acl" {
     }
     statement {
       rate_based_statement {
-        limit = 5000
+        limit = 15000
+        scope_down_statement {
+          not_statement {
+            statement {
+              ip_set_reference_statement {
+                arn = aws_wafv2_ip_set.trusted[0].arn
+              }
+            }
+          }
+        }
       }
     }
     visibility_config {


### PR DESCRIPTION
There are two problems here. The first is that requests from users who
are uploading 10000 files are hitting the rate limit and they're getting
forbidden from the front end when we try to make an API call.

The second problem is that the backend checks are hitting the rate limit
when they try to call the API.

The limit increase is to stop users seeing 403 errors and the
scope_down_statement stops the rate limiting rule counting IPs in the
trusted IP set, which includes the NAT gateway IPs so this should stop
the backend checks counting towards the limit.

This isn't foolproof, it works off the IP in the header which can be
spoofed but it should stop most obvious DDOS attempts.
