### PR TITLE
Add event bridge permissions.

### DIFF
--- a/kms/templates/cloudwatch.json.tpl
+++ b/kms/templates/cloudwatch.json.tpl
@@ -24,6 +24,18 @@
         "kms:GenerateDataKey*"
       ],
       "Resource": "*"
+    },
+    {
+      "Sid": "Allow_EventBridge_for_CMK",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "events.amazonaws.com"
+      },
+      "Action": [
+        "kms:Decrypt",
+        "kms:GenerateDataKey*"
+      ],
+      "Resource": "*"
     }
   ]
 }


### PR DESCRIPTION
Event bridge is sending messages to the notification SNS topic in the
management account and that topic is encrypted at rest so event bridge
needs permission to decrypt with this KMS key.
