### PR TITLE
Remove the default_statement

### DIFF
--- a/sqs/templates/transform_engine_retry_policy.json.tpl
+++ b/sqs/templates/transform_engine_retry_policy.json.tpl
@@ -3,21 +3,6 @@
   "Id": "transform_engine_retry",
   "Statement": [
     {
-      "Sid": "default_statement",
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "*"
-      },
-      "Action": [
-        "SQS:GetQueueAttributes",
-        "SQS:GetQueueUrl",
-        "SQS:ListDeadLetterSourceQueues",
-        "SQS:ReceiveMessage",
-        "SQS:SendMessage"
-      ],
-      "Resource": "arn:aws:sqs:${region}:${account_id}:${sqs_name}"
-    },
-    {
       "Sid": "transform_engine_permissions",
       "Effect": "Allow",
       "Principal": {

--- a/sqs/templates/transform_engine_v2_retry_policy.json.tpl
+++ b/sqs/templates/transform_engine_v2_retry_policy.json.tpl
@@ -3,21 +3,6 @@
   "Id": "transform_engine_v2_policy",
   "Statement": [
     {
-      "Sid": "transform_engine_v2_policy",
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "*"
-      },
-      "Action": [
-        "SQS:GetQueueAttributes",
-        "SQS:GetQueueUrl",
-        "SQS:ListDeadLetterSourceQueues",
-        "SQS:ReceiveMessage",
-        "SQS:SendMessage"
-      ],
-      "Resource": "arn:aws:sqs:${region}:${account_id}:${sqs_name}"
-    },
-    {
       "Effect": "Allow",
       "Principal": {
         "Service": "sns.amazonaws.com"


### PR DESCRIPTION
There is a statement in this policy which allows TRE to send messages to
this queue but the other statement isn't needed. SQS queues are owned by
default by the account so it should be able to invoke the notifications
lambda without this.

I've tested it and it will still invoke the lambda.

I'll mark this as draft while I check that TRE can still send messages.
