### PR TITLE
Update route53 module.

### DIFF
--- a/route53/locals.tf
+++ b/route53/locals.tf
@@ -1,4 +1,4 @@
 locals {
-  hosted_zone_id           = var.create_hosted_zone == true ? aws_route53_zone.hosted_zone[0].id : var.hosted_zone_id
-  hosted_zone_name_servers = var.create_hosted_zone == true ? aws_route53_zone.hosted_zone[0].name_servers : []
+  hosted_zone_id           = var.create_hosted_zone == true ? aws_route53_zone.hosted_zone[0].id : data.aws_route53_zone.hosted_zone[0].id
+  hosted_zone_name_servers = var.create_hosted_zone == true ? aws_route53_zone.hosted_zone[0].name_servers : data.aws_route53_zone.hosted_zone[0].name_servers
 }

--- a/route53/main.tf
+++ b/route53/main.tf
@@ -10,6 +10,11 @@ resource "aws_route53_zone" "hosted_zone" {
   )
 }
 
+data "aws_route53_zone" "hosted_zone" {
+  count = var.create_hosted_zone == true ? 0 : 1
+  name  = var.environment_full_name == "production" ? "${var.project}.${var.domain}" : "${var.project}-${var.environment_full_name}.${var.domain}"
+}
+
 resource "aws_route53_record" "dns" {
   count   = var.a_record_name == "" ? 0 : 1
   zone_id = local.hosted_zone_id

--- a/route53/outputs.tf
+++ b/route53/outputs.tf
@@ -1,3 +1,3 @@
 output "hosted_zone_id" {
-  value = var.create_hosted_zone == true ? aws_route53_zone.hosted_zone[0].zone_id : ""
+  value = var.create_hosted_zone == true ? aws_route53_zone.hosted_zone[0].zone_id : data.aws_route53_zone.hosted_zone[0].zone_id
 }


### PR DESCRIPTION
The module wasn't working when create_hosted_zone was set to false
because it was seting variables as empty string. I've put in a data
block which finds the existing hosted zone and use that for the outputs
and this is working for tdr-aws-accounts. It might have broken something
else.
