### PR TITLE
Make user session timeout configurable

### DIFF
--- a/lambda/signed_cookies.tf
+++ b/lambda/signed_cookies.tf
@@ -11,12 +11,13 @@ resource "aws_lambda_function" "signed_cookies_lambda_function" {
   tags                           = var.common_tags
   environment {
     variables = {
-      PRIVATE_KEY   = aws_kms_ciphertext.environment_vars_signed_cookies["private_key"].ciphertext_blob
-      FRONTEND_URL  = var.frontend_url
-      AUTH_URL      = var.auth_url
-      UPLOAD_DOMAIN = var.upload_domain
-      ENVIRONMENT   = var.environment_full
-      KEY_PAIR_ID   = aws_kms_ciphertext.environment_vars_signed_cookies["key_pair_id"].ciphertext_blob,
+      PRIVATE_KEY           = aws_kms_ciphertext.environment_vars_signed_cookies["private_key"].ciphertext_blob
+      FRONTEND_URL          = var.frontend_url
+      AUTH_URL              = var.auth_url
+      UPLOAD_DOMAIN         = var.upload_domain
+      ENVIRONMENT           = var.environment_full
+      KEY_PAIR_ID           = aws_kms_ciphertext.environment_vars_signed_cookies["key_pair_id"].ciphertext_blob,
+      COOKIE_EXPIRY_MINUTES = var.user_session_timeout_mins
     }
   }
 

--- a/lambda/variables.tf
+++ b/lambda/variables.tf
@@ -358,3 +358,8 @@ variable "da_event_bus_kms_key_arn" {
   description = "Digital Archiving event bus kms encryption arn"
   default     = ""
 }
+
+variable "user_session_timeout_mins" {
+  description = "Timeout for a user session in minutes"
+  default     = 60
+}


### PR DESCRIPTION
There will be instances where the user session timeout may need to be adjusted temporarily on a per environment basis. For example to accommodate a large consignment

Have the user session timeout as an environmental variable for the signed cookies lambda so the cookie timeout matches the session timeout