### PR TITLE
Remove the templateId from the notifications environment variable

### DIFF
--- a/lambda/notifications.tf
+++ b/lambda/notifications.tf
@@ -24,14 +24,10 @@ resource "aws_lambda_function" "notifications_lambda_function" {
       SLACK_EXPORT_WEBHOOK                      = aws_kms_ciphertext.environment_vars_notifications["slack_export_webhook"].ciphertext_blob
       TO_EMAIL                                  = aws_kms_ciphertext.environment_vars_notifications["to_email"].ciphertext_blob
       DA_EVENT_BUS                              = aws_kms_ciphertext.environment_vars_notifications["da_event_bus"].ciphertext_blob
-      TRANSFER_COMPLETE_TEMPLATE_ID             = aws_kms_ciphertext.environment_vars_notifications["transfer_complete_template_id"].ciphertext_blob
-      METADATA_REVIEW_REQUESTED_TB_TEMPLATE_ID  = aws_kms_ciphertext.environment_vars_notifications["metadata_review_requested_tb_template_id"].ciphertext_blob
-      METADATA_REVIEW_REQUESTED_DTA_TEMPLATE_ID = aws_kms_ciphertext.environment_vars_notifications["metadata_review_requested_dta_template_id"].ciphertext_blob
-      METADATA_REVIEW_REJECTED_TEMPLATE_ID      = aws_kms_ciphertext.environment_vars_notifications["metadata_review_rejected_template_id"].ciphertext_blob
-      METADATA_REVIEW_APPROVED_TEMPLATE_ID      = aws_kms_ciphertext.environment_vars_notifications["metadata_review_approved_template_id"].ciphertext_blob
       GOV_UK_NOTIFY_API_KEY                     = aws_kms_ciphertext.environment_vars_notifications["gov_uk_notify_api_key"].ciphertext_blob
       SEND_GOV_UK_NOTIFICATIONS                 = aws_kms_ciphertext.environment_vars_notifications["send_gov_uk_notifications"].ciphertext_blob
       TDR_INBOX_EMAIL                           = aws_kms_ciphertext.environment_vars_notifications["tdr_inbox_email"].ciphertext_blob
+      ENVIRONMENT                               = aws_kms_ciphertext.environment_vars_notifications["environment"].ciphertext_blob
     }
   }
 
@@ -54,14 +50,10 @@ resource "aws_kms_ciphertext" "environment_vars_notifications" {
     slack_export_webhook                      = data.aws_ssm_parameter.slack_export_webhook[0].value,
     to_email                                  = "tdr-secops@nationalarchives.gov.uk",
     da_event_bus                              = var.da_event_bus_arn
-    transfer_complete_template_id             = data.aws_ssm_parameter.gov_uk_transfer_complete_template_id[0].value
-    metadata_review_requested_tb_template_id  = data.aws_ssm_parameter.gov_uk_metadata_review_requested_tb_template_id[0].value
-    metadata_review_requested_dta_template_id = data.aws_ssm_parameter.gov_uk_metadata_review_requested_dta_template_id[0].value
-    metadata_review_rejected_template_id      = data.aws_ssm_parameter.gov_uk_metadata_review_rejected_template_id[0].value
-    metadata_review_approved_template_id      = data.aws_ssm_parameter.gov_uk_metadata_review_approved_template_id[0].value
     gov_uk_notify_api_key                     = data.aws_ssm_parameter.gov_uk_notify_api_key[0].value
     send_gov_uk_notifications                 = local.environment == "prod"
     tdr_inbox_email                           = local.environment == "prod" ? "tdr@nationalarchives.gov.uk" : "tdrtest@nationalarchives.gov.uk"
+    environment                               = local.environment
   }
   # This lambda is created by the tdr-terraform-backend project as it only exists in the management account so we can't use any KMS keys
   # created by the terraform environments project as they won't exist when we first run the backend project.

--- a/lambda/notifications.tf
+++ b/lambda/notifications.tf
@@ -17,17 +17,17 @@ resource "aws_lambda_function" "notifications_lambda_function" {
   tags                           = var.common_tags
   environment {
     variables = {
-      SLACK_WEBHOOK                             = aws_kms_ciphertext.environment_vars_notifications["slack_notifications_webhook"].ciphertext_blob
-      SLACK_JUDGMENT_WEBHOOK                    = aws_kms_ciphertext.environment_vars_notifications["slack_judgment_webhook"].ciphertext_blob
-      SLACK_STANDARD_WEBHOOK                    = aws_kms_ciphertext.environment_vars_notifications["slack_standard_webhook"].ciphertext_blob
-      SLACK_TDR_WEBHOOK                         = aws_kms_ciphertext.environment_vars_notifications["slack_tdr_webhook"].ciphertext_blob
-      SLACK_EXPORT_WEBHOOK                      = aws_kms_ciphertext.environment_vars_notifications["slack_export_webhook"].ciphertext_blob
-      TO_EMAIL                                  = aws_kms_ciphertext.environment_vars_notifications["to_email"].ciphertext_blob
-      DA_EVENT_BUS                              = aws_kms_ciphertext.environment_vars_notifications["da_event_bus"].ciphertext_blob
-      GOV_UK_NOTIFY_API_KEY                     = aws_kms_ciphertext.environment_vars_notifications["gov_uk_notify_api_key"].ciphertext_blob
-      SEND_GOV_UK_NOTIFICATIONS                 = aws_kms_ciphertext.environment_vars_notifications["send_gov_uk_notifications"].ciphertext_blob
-      TDR_INBOX_EMAIL                           = aws_kms_ciphertext.environment_vars_notifications["tdr_inbox_email"].ciphertext_blob
-      ENVIRONMENT                               = aws_kms_ciphertext.environment_vars_notifications["environment"].ciphertext_blob
+      SLACK_WEBHOOK             = aws_kms_ciphertext.environment_vars_notifications["slack_notifications_webhook"].ciphertext_blob
+      SLACK_JUDGMENT_WEBHOOK    = aws_kms_ciphertext.environment_vars_notifications["slack_judgment_webhook"].ciphertext_blob
+      SLACK_STANDARD_WEBHOOK    = aws_kms_ciphertext.environment_vars_notifications["slack_standard_webhook"].ciphertext_blob
+      SLACK_TDR_WEBHOOK         = aws_kms_ciphertext.environment_vars_notifications["slack_tdr_webhook"].ciphertext_blob
+      SLACK_EXPORT_WEBHOOK      = aws_kms_ciphertext.environment_vars_notifications["slack_export_webhook"].ciphertext_blob
+      TO_EMAIL                  = aws_kms_ciphertext.environment_vars_notifications["to_email"].ciphertext_blob
+      DA_EVENT_BUS              = aws_kms_ciphertext.environment_vars_notifications["da_event_bus"].ciphertext_blob
+      GOV_UK_NOTIFY_API_KEY     = aws_kms_ciphertext.environment_vars_notifications["gov_uk_notify_api_key"].ciphertext_blob
+      SEND_GOV_UK_NOTIFICATIONS = aws_kms_ciphertext.environment_vars_notifications["send_gov_uk_notifications"].ciphertext_blob
+      TDR_INBOX_EMAIL           = aws_kms_ciphertext.environment_vars_notifications["tdr_inbox_email"].ciphertext_blob
+      ENVIRONMENT               = aws_kms_ciphertext.environment_vars_notifications["environment"].ciphertext_blob
     }
   }
 
@@ -43,17 +43,17 @@ resource "aws_lambda_function" "notifications_lambda_function" {
 
 resource "aws_kms_ciphertext" "environment_vars_notifications" {
   for_each = local.count_notifications == 0 ? {} : {
-    slack_tdr_webhook                         = data.aws_ssm_parameter.slack_webhook[0].value,
-    slack_judgment_webhook                    = data.aws_ssm_parameter.slack_judgment_webhook[0].value,
-    slack_standard_webhook                    = data.aws_ssm_parameter.slack_standard_webhook[0].value,
-    slack_notifications_webhook               = data.aws_ssm_parameter.slack_notifications_webhook[0].value,
-    slack_export_webhook                      = data.aws_ssm_parameter.slack_export_webhook[0].value,
-    to_email                                  = "tdr-secops@nationalarchives.gov.uk",
-    da_event_bus                              = var.da_event_bus_arn
-    gov_uk_notify_api_key                     = data.aws_ssm_parameter.gov_uk_notify_api_key[0].value
-    send_gov_uk_notifications                 = local.environment == "prod"
-    tdr_inbox_email                           = local.environment == "prod" ? "tdr@nationalarchives.gov.uk" : "tdrtest@nationalarchives.gov.uk"
-    environment                               = local.environment
+    slack_tdr_webhook           = data.aws_ssm_parameter.slack_webhook[0].value,
+    slack_judgment_webhook      = data.aws_ssm_parameter.slack_judgment_webhook[0].value,
+    slack_standard_webhook      = data.aws_ssm_parameter.slack_standard_webhook[0].value,
+    slack_notifications_webhook = data.aws_ssm_parameter.slack_notifications_webhook[0].value,
+    slack_export_webhook        = data.aws_ssm_parameter.slack_export_webhook[0].value,
+    to_email                    = "tdr-secops@nationalarchives.gov.uk",
+    da_event_bus                = var.da_event_bus_arn
+    gov_uk_notify_api_key       = data.aws_ssm_parameter.gov_uk_notify_api_key[0].value
+    send_gov_uk_notifications   = local.environment == "prod"
+    tdr_inbox_email             = local.environment == "prod" ? "tdr@nationalarchives.gov.uk" : "tdrtest@nationalarchives.gov.uk"
+    environment                 = local.environment
   }
   # This lambda is created by the tdr-terraform-backend project as it only exists in the management account so we can't use any KMS keys
   # created by the terraform environments project as they won't exist when we first run the backend project.

--- a/lambda/notifications.tf
+++ b/lambda/notifications.tf
@@ -92,26 +92,6 @@ data "aws_ssm_parameter" "slack_export_webhook" {
   name  = "/${local.environment}/slack/export/webhook"
 }
 
-data "aws_ssm_parameter" "gov_uk_transfer_complete_template_id" {
-  count = local.count_notifications
-  name  = "/${local.environment}/gov_uk_notify/transfer_complete_template_id"
-}
-
-data "aws_ssm_parameter" "gov_uk_metadata_review_requested_tb_template_id" {
-  count = local.count_notifications
-  name  = "/${local.environment}/gov_uk_notify/metadata_review_requested_tb_template_id"
-}
-
-data "aws_ssm_parameter" "gov_uk_metadata_review_requested_dta_template_id" {
-  count = local.count_notifications
-  name  = "/${local.environment}/gov_uk_notify/metadata_review_requested_dta_template_id"
-}
-
-data "aws_ssm_parameter" "gov_uk_metadata_review_rejected_template_id" {
-  count = local.count_notifications
-  name  = "/${local.environment}/gov_uk_notify/metadata_review_rejected_template_id"
-}
-
 data "aws_ssm_parameter" "gov_uk_metadata_review_approved_template_id" {
   count = local.count_notifications
   name  = "/${local.environment}/gov_uk_notify/metadata_review_approved_template_id"


### PR DESCRIPTION
We have exceeded the 4kb limit for the notifications environment variable lambda. These have now been moved to the notifications code.

Also added new ENVIRONMENT variable needed to differentiate between the environments