### PR TITLE
cloudfront certificate module warning fix. Add required_providers

### DIFF
--- a/certificatemanager/versions.tf
+++ b/certificatemanager/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}


### PR DESCRIPTION
With terraform init there was a warning 
```
in module "cloudfront_certificate":
aws = aws.useast1
There is no explicit declaration for local provider name "aws" in module.cloudfront_certificate, so Terraform is assuming you mean to pass a configuration for "hashicorp/aws".
```
To remove warning do as suggested by terraform
`If you also control the child module, add a required_providers entry named "aws" with the source address "hashicorp/aws".`