### PR TITLE
Tdrd 607 fix terraform warnings

### DIFF
--- a/certificatemanager/versions.tf
+++ b/certificatemanager/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}

--- a/lambda/log_data.tf
+++ b/lambda/log_data.tf
@@ -59,10 +59,6 @@ resource "aws_lambda_function" "log_data_lambda" {
       TARGET_S3_BUCKET = aws_kms_ciphertext.environment_vars_log_data["target_s3_bucket"].ciphertext_blob
     }
   }
-
-  lifecycle {
-    ignore_changes = [last_modified]
-  }
 }
 
 resource "aws_kms_ciphertext" "environment_vars_log_data" {

--- a/s3/main.tf
+++ b/s3/main.tf
@@ -1,12 +1,7 @@
 resource "aws_s3_bucket" "log_bucket" {
   count         = var.access_logs == true && var.apply_resource == true ? 1 : 0
-  acl           = "log-delivery-write"
   bucket        = "${local.bucket_name}-logs"
   force_destroy = var.force_destroy
-
-  versioning {
-    enabled = true
-  }
 
   tags = merge(
     var.common_tags,
@@ -14,6 +9,23 @@ resource "aws_s3_bucket" "log_bucket" {
       { "Name" = "${local.bucket_name}-logs" }
     )
   )
+}
+
+resource "aws_s3_bucket_versioning" "log_bucket_versioning" {
+  count = var.access_logs == true && var.apply_resource == true ? 1 : 0
+
+  bucket = aws_s3_bucket.log_bucket[0].id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_acl" "log_bucket_acl" {
+  count = var.access_logs == true && var.apply_resource == true ? 1 : 0
+
+  bucket = aws_s3_bucket.log_bucket[count.index].id
+  acl    = "log-delivery-write"
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "bucket_encryption" {
@@ -41,7 +53,7 @@ resource "aws_s3_bucket_public_access_block" "log_bucket" {
 resource "aws_s3_bucket_policy" "log_bucket" {
   count      = var.access_logs == true && var.apply_resource == true ? 1 : 0
   bucket     = aws_s3_bucket.log_bucket.*.id[0]
-  policy     = templatefile("./tdr-terraform-modules/s3/templates/secure_transport.json.tpl", { bucket_name = aws_s3_bucket.log_bucket.*.id[0] })
+  policy     = templatefile("./tdr-terraform-modules/s3/templates/secure_transport.json.tpl", { bucket_name = aws_s3_bucket.log_bucket.*.id[0], canonical_user_grants = var.canonical_user_grants })
   depends_on = [aws_s3_bucket_public_access_block.log_bucket]
 }
 
@@ -59,54 +71,7 @@ resource "aws_s3_bucket_notification" "log_bucket_notification" {
 resource "aws_s3_bucket" "bucket" {
   count         = var.apply_resource == true ? 1 : 0
   bucket        = local.bucket_name
-  acl           = length(var.canonical_user_grants) == 0 ? var.acl : null
   force_destroy = var.force_destroy
-
-  dynamic "grant" {
-    for_each = var.canonical_user_grants
-    content {
-      permissions = grant.value.permissions
-      type        = "CanonicalUser"
-      id          = grant.value.id
-    }
-  }
-
-  versioning {
-    enabled = var.versioning
-  }
-
-  dynamic "lifecycle_rule" {
-    for_each = var.abort_incomplete_uploads == true ? ["include_block"] : []
-    content {
-      id                                     = "abort-incomplete-uploads"
-      enabled                                = true
-      abort_incomplete_multipart_upload_days = 7
-      expiration {
-        days                         = 0
-        expired_object_delete_marker = false
-      }
-    }
-  }
-
-  dynamic "logging" {
-    for_each = var.access_logs == true ? ["include_block"] : []
-    content {
-      target_bucket = aws_s3_bucket.log_bucket.*.id[0]
-      target_prefix = "${local.bucket_name}/${data.aws_caller_identity.current.account_id}/"
-    }
-  }
-
-  dynamic "cors_rule" {
-    for_each = length(var.cors_urls) > 0 ? ["include-cors"] : []
-    content {
-      allowed_headers = ["*"]
-      allowed_methods = ["PUT", "POST", "GET"]
-      allowed_origins = var.cors_urls
-      expose_headers  = ["ETag", "x-amz-server-side-encryption", "x-amz-request-id", "x-amz-id-2"]
-      max_age_seconds = 3000
-    }
-  }
-
   tags = merge(
     var.common_tags,
     tomap(
@@ -114,17 +79,78 @@ resource "aws_s3_bucket" "bucket" {
     )
   )
 }
+resource "aws_s3_bucket_acl" "bucket_acl" {
+  count = var.apply_resource == true && length(var.canonical_user_grants) == 0 ? 1 : 0
+
+  bucket = aws_s3_bucket.bucket[0].id
+  acl    = var.acl
+}
+
+resource "aws_s3_bucket_versioning" "bucket_versioning" {
+  count = var.apply_resource == true && length(var.canonical_user_grants) == 0 ? 1 : 0
+
+  bucket = aws_s3_bucket.bucket[0].id
+
+  versioning_configuration {
+    status = "Enabled" # Use "Suspended" to disable versioning
+  }
+}
+
+resource "aws_s3_bucket_logging" "bucket_logging" {
+  count = var.access_logs == true && var.apply_resource == true ? 1 : 0
+
+  bucket        = aws_s3_bucket.bucket[0].id
+  target_bucket = aws_s3_bucket.log_bucket[0].id
+  target_prefix = "${local.bucket_name}/${data.aws_caller_identity.current.account_id}/"
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "bucket_lifecycle" {
+  count = var.apply_resource == true && var.abort_incomplete_uploads == true ? 1 : 0
+
+  bucket = aws_s3_bucket.bucket[0].id
+
+  rule {
+    id     = "abort-incomplete-uploads"
+    status = "Enabled"
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+
+    expiration {
+      days                         = 0
+      expired_object_delete_marker = false
+    }
+  }
+}
+
+resource "aws_s3_bucket_cors_configuration" "bucket_cors" {
+  count = var.apply_resource == true && length(var.cors_urls) > 0 ? 1 : 0
+
+  bucket = aws_s3_bucket.bucket[0].id
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["PUT", "POST", "GET"]
+    allowed_origins = var.cors_urls
+    expose_headers  = ["ETag", "x-amz-server-side-encryption", "x-amz-request-id", "x-amz-id-2"]
+    max_age_seconds = 3000
+  }
+}
+
+
 
 resource "aws_s3_bucket_policy" "bucket" {
   count  = var.apply_resource == true ? 1 : 0
   bucket = aws_s3_bucket.bucket.*.id[0]
   policy = local.environment == "mgmt" && contains(["log-data", "lambda_update"], var.bucket_policy) ? templatefile("./tdr-terraform-modules/s3/templates/${var.bucket_policy}.json.tpl",
     {
-      bucket_name        = aws_s3_bucket.bucket.*.id[0],
-      account_id         = data.aws_caller_identity.current.account_id,
-      external_account_1 = data.aws_ssm_parameter.intg_account_number.*.value[0],
-      external_account_2 = data.aws_ssm_parameter.staging_account_number.*.value[0],
-      external_account_3 = data.aws_ssm_parameter.prod_account_number.*.value[0]
+      bucket_name           = aws_s3_bucket.bucket.*.id[0],
+      account_id            = data.aws_caller_identity.current.account_id,
+      external_account_1    = data.aws_ssm_parameter.intg_account_number.*.value[0],
+      external_account_2    = data.aws_ssm_parameter.staging_account_number.*.value[0],
+      external_account_3    = data.aws_ssm_parameter.prod_account_number.*.value[0]
+      canonical_user_grants = var.canonical_user_grants
     }) : templatefile("./tdr-terraform-modules/s3/templates/${var.bucket_policy}.json.tpl",
     {
       bucket_name                  = aws_s3_bucket.bucket.*.id[0],
@@ -134,6 +160,7 @@ resource "aws_s3_bucket_policy" "bucket" {
       environment                  = local.environment, title_environment = title(local.environment),
       read_access_roles            = var.read_access_role_arns,
       cloudfront_distribution_arns = jsonencode(var.cloudfront_distribution_arns)
+      canonical_user_grants        = var.canonical_user_grants
   })
   depends_on = [aws_s3_bucket_public_access_block.bucket]
 }

--- a/s3/templates/alb_logging_euwest2.json.tpl
+++ b/s3/templates/alb_logging_euwest2.json.tpl
@@ -2,6 +2,20 @@
   "Id": "alb-logging-${bucket_name}",
   "Version": "2012-10-17",
   "Statement": [
+    %{ for grant in canonical_user_grants ~}
+    {
+      "Sid": "GrantPermissions-${grant.id}",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${grant.id}"
+      },
+      "Action": ${jsonencode(grant.permissions)},
+      "Resource": [
+        "arn:aws:s3:::${bucket_name}",
+        "arn:aws:s3:::${bucket_name}/*"
+      ]
+    },
+    %{ endfor ~}
     {
       "Effect": "Allow",
       "Principal": {

--- a/s3/templates/cloudfront_origin.json.tpl
+++ b/s3/templates/cloudfront_origin.json.tpl
@@ -2,6 +2,20 @@
   "Version": "2012-10-17",
   "Id": "CloudfrontUploadBucketPolicy",
   "Statement": [
+    %{ for grant in canonical_user_grants ~}
+    {
+      "Sid": "GrantPermissions-${grant.id}",
+      "Effect": "Allow",
+      "Principal": {
+          "AWS": "${grant.id}"
+      },
+      "Action": ${jsonencode(grant.permissions)},
+      "Resource": [
+          "arn:aws:s3:::${bucket_name}",
+          "arn:aws:s3:::${bucket_name}/*"
+      ]
+    },
+    %{ endfor ~}
     {
       "Effect": "Allow",
       "Principal": {

--- a/s3/templates/cloudtrail.json.tpl
+++ b/s3/templates/cloudtrail.json.tpl
@@ -1,6 +1,20 @@
 {
   "Version": "2012-10-17",
   "Statement": [
+    %{ for grant in canonical_user_grants ~}
+    {
+      "Sid": "GrantPermissions-${grant.id}",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${grant.id}"
+      },
+      "Action": ${jsonencode(grant.permissions)},
+      "Resource": [
+        "arn:aws:s3:::${bucket_name}",
+        "arn:aws:s3:::${bucket_name}/*"
+      ]
+    },
+    %{ endfor ~}
     {
       "Sid": "AWSCloudTrailAclCheck",
       "Effect": "Allow",

--- a/s3/templates/export_bucket.json.tpl
+++ b/s3/templates/export_bucket.json.tpl
@@ -2,6 +2,20 @@
   "Id": "secure-transport-${bucket_name}",
   "Version": "2012-10-17",
   "Statement": [
+    %{ for grant in canonical_user_grants ~}
+      {
+      "Sid": "GrantPermissions-${grant.id}",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${grant.id}"
+      },
+      "Action": ${jsonencode(grant.permissions)},
+      "Resource": [
+        "arn:aws:s3:::${bucket_name}",
+        "arn:aws:s3:::${bucket_name}/*"
+      ]
+    },
+    %{ endfor ~}
     {
       "Sid": "AllowSSLRequestsOnly",
       "Action": "s3:*",

--- a/s3/templates/lambda_update.json.tpl
+++ b/s3/templates/lambda_update.json.tpl
@@ -2,6 +2,20 @@
   "Version": "2012-10-17",
   "Id": "secure-transport-tdr-backend-code-mgmt",
   "Statement": [
+    %{ for grant in canonical_user_grants ~}
+    {
+      "Sid": "GrantPermissions-${grant.id}",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${grant.id}"
+      },
+      "Action": ${jsonencode(grant.permissions)},
+      "Resource": [
+        "arn:aws:s3:::${bucket_name}",
+        "arn:aws:s3:::${bucket_name}/*"
+      ]
+    },
+    %{ endfor ~}
     {
       "Sid": "AllowSSLRequestsOnly",
       "Effect": "Deny",

--- a/s3/templates/log-data.json.tpl
+++ b/s3/templates/log-data.json.tpl
@@ -2,6 +2,20 @@
   "Id": "secure-logging-${bucket_name}",
   "Version": "2012-10-17",
   "Statement": [
+    %{ for grant in canonical_user_grants ~}
+    {
+      "Sid": "GrantPermissions-${grant.id}",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${grant.id}"
+      },
+      "Action": ${jsonencode(grant.permissions)},
+      "Resource": [
+        "arn:aws:s3:::${bucket_name}",
+        "arn:aws:s3:::${bucket_name}/*"
+      ]
+    },
+    %{ endfor ~}
     {
       "Sid": "AllowSSLRequestsOnly",
       "Action": "s3:*",

--- a/s3/templates/secure_transport.json.tpl
+++ b/s3/templates/secure_transport.json.tpl
@@ -2,7 +2,21 @@
   "Id": "secure-transport-${bucket_name}",
   "Version": "2012-10-17",
   "Statement": [
+  %{ for grant in canonical_user_grants ~}
     {
+      "Sid": "GrantPermissions-${grant.id}",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${grant.id}"
+      },
+      "Action": ${jsonencode(grant.permissions)},
+      "Resource": [
+        "arn:aws:s3:::${bucket_name}",
+        "arn:aws:s3:::${bucket_name}/*"
+       ]
+      },
+  %{ endfor ~}
+{
       "Sid": "AllowSSLRequestsOnly",
       "Action": "s3:*",
       "Effect": "Deny",

--- a/ssm_parameter/main.tf
+++ b/ssm_parameter/main.tf
@@ -30,7 +30,6 @@ resource "aws_ssm_parameter" "ssm_parameter" {
   value       = each.value.value
   description = each.value.description
   tier        = each.value.tier
-  overwrite   = true
   tags        = var.common_tags
 }
 
@@ -41,7 +40,6 @@ resource "aws_ssm_parameter" "ssm_parameter_ignore_value" {
   value       = each.value.value
   description = each.value.description
   tier        = each.value.tier
-  overwrite   = true
   tags        = var.common_tags
   lifecycle {
     ignore_changes = [value]


### PR DESCRIPTION
**certificatemanager**  If passing providers the sub module should declare the aws provide with required_providers - warning default used otherwise. Needed tp pass different region provider as certificates are not eu-west-2. Providers can only be created in root

**lambda** in an aws_lambda_function the lifecycle block with ignore_changes for last_modified is no longer necessary in Terraform when using the aws_lambda_function resource because last_modified is now read-only and automatically managed by AWS.

If the purpose of ignoring last_modified was to avoid Terraform noticing changes unrelated to your Lambda function deployment, you no longer need to do anything. The last_modified attribute is informational and will not trigger updates or conflicts in recent versions of the AWS provider.

 **S3** module  the resource aws_s3_bucket has attributes `logging,` `lifecycle_rule`, `cors_rule` ,`acl `and` versioning `should be in a separate resources. The` grants `should be defined in the policy