### PR TITLE
Tdrd 339 automated or semi automated workflow for blocking i ps with malicious activity

### DIFF
--- a/waf/main.tf
+++ b/waf/main.tf
@@ -86,7 +86,7 @@ resource "aws_wafv2_rule_group" "rule_group" {
 }
 
 resource "aws_wafv2_rule_group" "block_ips_rule_group" {
-  count              = var.blocked_ips == "" ? 0 : 1
+  count    = var.blocked_ips == "" ? 0 : 1
   capacity = 1
   name     = "block-ips-rule-group"
   scope    = "REGIONAL"
@@ -162,6 +162,25 @@ resource "aws_wafv2_web_acl" "acl" {
     visibility_config {
       cloudwatch_metrics_enabled = false
       metric_name                = "acl-rule-metric"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  rule {
+    count    = var.blocked_ips == "" ? 0 : 1
+    name     = "block-ips-rule-group"
+    priority = 2
+    override_action {
+      none {}
+    }
+    statement {
+      rule_group_reference_statement {
+        arn = aws_wafv2_rule_group.block_ips_rule_group[0].arn
+      }
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "block-ips-rule-group"
       sampled_requests_enabled   = false
     }
   }

--- a/waf/main.tf
+++ b/waf/main.tf
@@ -166,22 +166,24 @@ resource "aws_wafv2_web_acl" "acl" {
     }
   }
 
-  rule {
-    count    = var.blocked_ips == "" ? 0 : 1
-    name     = "block-ips-rule-group"
-    priority = 2
-    override_action {
-      none {}
-    }
-    statement {
-      rule_group_reference_statement {
-        arn = aws_wafv2_rule_group.block_ips_rule_group[0].arn
+  dynamic "rule" {
+    for_each = var.blocked_ips == "" ? [] : [1]
+    content {
+      name     = "block-ips-rule-group"
+      priority = 2
+      override_action {
+        none {}
       }
-    }
-    visibility_config {
-      cloudwatch_metrics_enabled = false
-      metric_name                = "block-ips-rule-group"
-      sampled_requests_enabled   = false
+      statement {
+        rule_group_reference_statement {
+          arn = aws_wafv2_rule_group.block_ips_rule_group[0].arn
+        }
+      }
+      visibility_config {
+        cloudwatch_metrics_enabled = false
+        metric_name                = "block-ips-rule-group"
+        sampled_requests_enabled   = false
+      }
     }
   }
 

--- a/waf/main.tf
+++ b/waf/main.tf
@@ -77,10 +77,21 @@ resource "aws_wafv2_rule_group" "rule_group" {
       sampled_requests_enabled   = false
     }
   }
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "geo-match-metric"
+    sampled_requests_enabled   = false
+  }
+}
+
+resource "aws_wafv2_rule_group" "block_ips_rule_group" {
+  capacity = 1
+  name     = "block-ips-rule-group"
+  scope    = "REGIONAL"
 
   rule {
     name     = "BlockIPsRule"
-    priority = 40
+    priority = 10
     action {
       block {}
     }
@@ -98,7 +109,7 @@ resource "aws_wafv2_rule_group" "rule_group" {
 
   visibility_config {
     cloudwatch_metrics_enabled = false
-    metric_name                = "geo-match-metric"
+    metric_name                = "block-ips-rule-group"
     sampled_requests_enabled   = false
   }
 }
@@ -150,6 +161,24 @@ resource "aws_wafv2_web_acl" "acl" {
     visibility_config {
       cloudwatch_metrics_enabled = false
       metric_name                = "acl-rule-metric"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  rule {
+    name     = "acl-rule-blocked_ips"
+    priority = 2
+    override_action {
+      none {}
+    }
+    statement {
+      rule_group_reference_statement {
+        arn = aws_wafv2_rule_group.block_ips_rule_group.arn
+      }
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "acl-rule-metric-blocked-ips"
       sampled_requests_enabled   = false
     }
   }

--- a/waf/main.tf
+++ b/waf/main.tf
@@ -7,7 +7,6 @@ resource "aws_wafv2_ip_set" "trusted" {
 }
 
 resource "aws_wafv2_ip_set" "blocked_ips" {
-  count              = var.blocked_ips == "" ? 0 : 1
   name               = "${var.project}-${var.function}-${var.environment}-blockedIps"
   scope              = "REGIONAL"
   ip_address_version = "IPV4"
@@ -102,7 +101,7 @@ resource "aws_wafv2_web_acl" "acl" {
       }
       statement {
         ip_set_reference_statement {
-          arn = aws_wafv2_ip_set.blocked_ips[0].arn
+          arn = aws_wafv2_ip_set.blocked_ips.arn
         }
       }
       visibility_config {
@@ -157,7 +156,7 @@ resource "aws_wafv2_web_acl" "acl" {
     }
   }
 
-   dynamic "rule" {
+  dynamic "rule" {
     for_each = toset(var.aws_managed_rules)
     content {
       name     = rule.value.name

--- a/waf/main.tf
+++ b/waf/main.tf
@@ -80,7 +80,7 @@ resource "aws_wafv2_rule_group" "rule_group" {
 
   rule {
     name     = "BlockIPsRule"
-    priority = 10
+    priority = 40
     action {
       block {}
     }

--- a/waf/outputs.tf
+++ b/waf/outputs.tf
@@ -10,3 +10,7 @@ output "blocked_ip_set_arn" {
   value = var.blocked_ips == "" ? "" : aws_wafv2_ip_set.blocked_ips[0].arn
 }
 
+output "blocked_rule_group_arn" {
+  value = aws_wafv2_rule_group.block_ips_rule_group[0].arn
+}
+

--- a/waf/outputs.tf
+++ b/waf/outputs.tf
@@ -9,8 +9,3 @@ output "rule_group_arn" {
 output "blocked_ip_set_arn" {
   value = var.blocked_ips == "" ? "" : aws_wafv2_ip_set.blocked_ips[0].arn
 }
-
-output "blocked_rule_group_arn" {
-  value = length(aws_wafv2_rule_group.block_ips_rule_group) > 0 ? aws_wafv2_rule_group.block_ips_rule_group[0].arn : ""
-}
-

--- a/waf/outputs.tf
+++ b/waf/outputs.tf
@@ -5,3 +5,12 @@ output "ip_set_arn" {
 output "rule_group_arn" {
   value = aws_wafv2_rule_group.rule_group.arn
 }
+
+output "block_ips_rule_group_arn" {
+  value = aws_wafv2_rule_group.block_ips_rule_group.arn
+}
+
+output "blocked_ip_set_arn" {
+  value = var.blocked_ips == "" ? "" : aws_wafv2_ip_set.blocked_ips[0].arn
+}
+

--- a/waf/outputs.tf
+++ b/waf/outputs.tf
@@ -7,5 +7,5 @@ output "rule_group_arn" {
 }
 
 output "blocked_ip_set_arn" {
-  value = var.blocked_ips == "" ? "" : aws_wafv2_ip_set.blocked_ips[0].arn
+  value = var.blocked_ips == "" ? "" : aws_wafv2_ip_set.blocked_ips.arn
 }

--- a/waf/outputs.tf
+++ b/waf/outputs.tf
@@ -11,6 +11,6 @@ output "blocked_ip_set_arn" {
 }
 
 output "blocked_rule_group_arn" {
-  value = aws_wafv2_rule_group.block_ips_rule_group[0].arn
+  value = length(aws_wafv2_rule_group.block_ips_rule_group) > 0 ? aws_wafv2_rule_group.block_ips_rule_group[0].arn : ""
 }
 

--- a/waf/outputs.tf
+++ b/waf/outputs.tf
@@ -6,10 +6,6 @@ output "rule_group_arn" {
   value = aws_wafv2_rule_group.rule_group.arn
 }
 
-output "block_ips_rule_group_arn" {
-  value = aws_wafv2_rule_group.block_ips_rule_group.arn
-}
-
 output "blocked_ip_set_arn" {
   value = var.blocked_ips == "" ? "" : aws_wafv2_ip_set.blocked_ips[0].arn
 }

--- a/waf/variables.tf
+++ b/waf/variables.tf
@@ -54,11 +54,11 @@ variable "aws_managed_rules" {
     metric_name                              = string
   }))
   default = [
-    { name = "AWS-AWSManagedRulesAmazonIpReputationList", priority = 2, managed_rule_group_statement_name = "AWSManagedRulesAmazonIpReputationList", managed_rule_group_statement_vendor_name = "AWS", metric_name = "AWS-AWSManagedRulesAmazonIpReputationList" },
-    { name = "AWS-AWSManagedRulesCommonRuleSet", priority = 3, managed_rule_group_statement_name = "AWSManagedRulesCommonRuleSet", managed_rule_group_statement_vendor_name = "AWS", metric_name = "AWS-AWSManagedRulesCommonRuleSet" },
-    { name = "AWS-AWSManagedRulesKnownBadInputsRuleSet", priority = 4, managed_rule_group_statement_name = "AWSManagedRulesKnownBadInputsRuleSet", managed_rule_group_statement_vendor_name = "AWS", metric_name = "AWS-AWSManagedRulesKnownBadInputsRuleSet" },
-    { name = "AWS-AWSManagedRulesLinuxRuleSet", priority = 5, managed_rule_group_statement_name = "AWSManagedRulesLinuxRuleSet", managed_rule_group_statement_vendor_name = "AWS", metric_name = "AWS-AWSManagedRulesLinuxRuleSet" },
-    { name = "AWS-AWSManagedRulesUnixRuleSet", priority = 6, managed_rule_group_statement_name = "AWSManagedRulesUnixRuleSet", managed_rule_group_statement_vendor_name = "AWS", metric_name = "AWS-AWSManagedRulesUnixRuleSet" },
-    { name = "AWS-AWSManagedRulesSQLiRuleSet", priority = 7, managed_rule_group_statement_name = "AWSManagedRulesSQLiRuleSet", managed_rule_group_statement_vendor_name = "AWS", metric_name = "AWS-AWSManagedRulesSQLiRuleSet" }
+    { name = "AWS-AWSManagedRulesAmazonIpReputationList", priority = 3, managed_rule_group_statement_name = "AWSManagedRulesAmazonIpReputationList", managed_rule_group_statement_vendor_name = "AWS", metric_name = "AWS-AWSManagedRulesAmazonIpReputationList" },
+    { name = "AWS-AWSManagedRulesCommonRuleSet", priority = 4, managed_rule_group_statement_name = "AWSManagedRulesCommonRuleSet", managed_rule_group_statement_vendor_name = "AWS", metric_name = "AWS-AWSManagedRulesCommonRuleSet" },
+    { name = "AWS-AWSManagedRulesKnownBadInputsRuleSet", priority = 5, managed_rule_group_statement_name = "AWSManagedRulesKnownBadInputsRuleSet", managed_rule_group_statement_vendor_name = "AWS", metric_name = "AWS-AWSManagedRulesKnownBadInputsRuleSet" },
+    { name = "AWS-AWSManagedRulesLinuxRuleSet", priority = 6, managed_rule_group_statement_name = "AWSManagedRulesLinuxRuleSet", managed_rule_group_statement_vendor_name = "AWS", metric_name = "AWS-AWSManagedRulesLinuxRuleSet" },
+    { name = "AWS-AWSManagedRulesUnixRuleSet", priority = 7, managed_rule_group_statement_name = "AWSManagedRulesUnixRuleSet", managed_rule_group_statement_vendor_name = "AWS", metric_name = "AWS-AWSManagedRulesUnixRuleSet" },
+    { name = "AWS-AWSManagedRulesSQLiRuleSet", priority = 8, managed_rule_group_statement_name = "AWSManagedRulesSQLiRuleSet", managed_rule_group_statement_vendor_name = "AWS", metric_name = "AWS-AWSManagedRulesSQLiRuleSet" }
   ]
 }

--- a/waf/variables.tf
+++ b/waf/variables.tf
@@ -23,8 +23,13 @@ variable "trusted_ips" {
   default     = ""
 }
 
+variable "blocked_ips" {
+  description = "blocked IP addresses"
+  default     = ""
+}
+
 variable "restricted_uri" {
-  description = "Resricted URI"
+  description = "Restricted URI"
   default     = ""
 }
 


### PR DESCRIPTION
Create a new IPSet for blocked IPs, this will not be removed but can be empty (deletions whilst in use causes terraform problems)
The rule to delete will be added directly to the acl (no need to use rule_group). The rule will only be added if there are IPs to block as rule incur a cost.
Priorities need to change so blocking will happen even if an IP had been previously added to whitelist)