### PR TITLE
Update signed_cookies.tf

### DIFF
--- a/lambda/signed_cookies.tf
+++ b/lambda/signed_cookies.tf
@@ -3,7 +3,7 @@ resource "aws_lambda_function" "signed_cookies_lambda_function" {
   function_name                  = local.signed_cookies_function_name
   handler                        = "signed_cookies.handler"
   role                           = aws_iam_role.signed_cookies_lambda_iam_role.*.arn[0]
-  runtime                        = "python3.13"
+  runtime                        = "python3.9"
   filename                       = "${path.module}/functions/signed-cookies.zip"
   timeout                        = var.timeout_seconds
   memory_size                    = 1024


### PR DESCRIPTION
revert to 3.9 - not working in AWS on anything above 3.9
needs more work to fix